### PR TITLE
Many new features and tweaks

### DIFF
--- a/addons/better-terrain/BetterTerrain.gd
+++ b/addons/better-terrain/BetterTerrain.gd
@@ -742,7 +742,7 @@ func set_cells(tm: TileMap, layer: int, coords: Array, type: int) -> bool:
 
 ## Replaces an existing tile on the [TileMap] for the [code]layer[/code]
 ## and [code]coord[/code] with a new tile in the provided terrain [code]type[/code] 
-## in [TileSet] [code]type[/code] *only if* there is a tile with a matching set of 
+## in [TileSet] [code]ts[/code] *only if* there is a tile with a matching set of 
 ## peering sides in this terrain.
 ## Returns [code]true[/code] if any tiles were changed. Use [method replace_cells]
 ## to replace multiple tiles at once.
@@ -779,7 +779,7 @@ func replace_cell(tm: TileMap, layer: int, coord: Vector2i, ts: TileSet, type: i
 
 ## Replaces existing tiles on the [TileMap] for the [code]layer[/code]
 ## and [code]coords[/code] with new tiles in the provided terrain [code]type[/code] 
-## in [TileSet] [code]type[/code] *only if* there is a tile with a matching set of 
+## in [TileSet] [code]ts[/code] *only if* there is a tile with a matching set of 
 ## peering sides in this terrain for each tile.
 ## Returns [code]true[/code] if any tiles were changed.
 func replace_cells(tm: TileMap, layer: int, coords: Array, ts: TileSet, type: int) -> bool:

--- a/addons/better-terrain/BetterTerrain.gd
+++ b/addons/better-terrain/BetterTerrain.gd
@@ -808,9 +808,6 @@ func replace_cells(tm: TileMap, layer: int, coords: Array, ts: TileSet, type: in
 			continue
 		for check_type in check_types:
 			var placed_peering = tile_peering_for_type(td, check_type)
-			if placed_peering.is_empty():
-				continue
-			
 			for pt in potential_tiles:
 				var check_peering = tile_peering_for_type(pt, check_type)
 				if placed_peering == check_peering:

--- a/addons/better-terrain/BetterTerrain.gd
+++ b/addons/better-terrain/BetterTerrain.gd
@@ -590,11 +590,12 @@ func get_tiles_in_terrain(ts: TileSet, type: int) -> Array[TileData]:
 	
 	var cache := _get_cache(ts)
 	var tiles = cache[type]
-	if tiles and tiles.size() > 0:
-		for c in tiles:
-			var source := ts.get_source(c[0]) as TileSetAtlasSource
-			var td := source.get_tile_data(c[1], c[2])
-			result.push_back(td)
+	if !tiles:
+		return result
+	for c in tiles:
+		var source := ts.get_source(c[0]) as TileSetAtlasSource
+		var td := source.get_tile_data(c[1], c[2])
+		result.push_back(td)
 	
 	return result
 
@@ -759,15 +760,19 @@ func replace_cell(tm: TileMap, layer: int, coord: Vector2i, ts: TileSet, type: i
 	var changed = false
 	var potential_tiles = get_tiles_in_terrain(ts, type)
 	var td = tm.get_cell_tile_data(layer, coord)
-	if td:
-		var placed_peering = tile_peering_for_type(td, type)
-		if not placed_peering.is_empty():
-			for pt in potential_tiles:
-				var check_peering = tile_peering_for_type(pt, type)
-				if placed_peering == check_peering:
-					var tile = cache[type].front()
-					tm.set_cell(layer, coord, tile[0], tile[1], tile[2])
-					changed = true
+	if !td:
+		return false
+	
+	var placed_peering = tile_peering_for_type(td, type)
+	if placed_peering.is_empty():
+		return false
+	
+	for pt in potential_tiles:
+		var check_peering = tile_peering_for_type(pt, type)
+		if placed_peering == check_peering:
+			var tile = cache[type].front()
+			tm.set_cell(layer, coord, tile[0], tile[1], tile[2])
+			changed = true
 	
 	return changed
 
@@ -792,15 +797,19 @@ func replace_cells(tm: TileMap, layer: int, coords: Array, ts: TileSet, type: in
 	var potential_tiles = get_tiles_in_terrain(ts, type)
 	for c in coords:
 		var td = tm.get_cell_tile_data(layer, c)
-		if td:
-			var placed_peering = tile_peering_for_type(td, type)
-			if not placed_peering.is_empty():
-				for pt in potential_tiles:
-					var check_peering = tile_peering_for_type(pt, type)
-					if placed_peering == check_peering:
-						var tile = cache[type].front()
-						tm.set_cell(layer, c, tile[0], tile[1], tile[2])
-						changed = true
+		if !td:
+			continue
+		
+		var placed_peering = tile_peering_for_type(td, type)
+		if placed_peering.is_empty():
+			continue
+		
+		for pt in potential_tiles:
+			var check_peering = tile_peering_for_type(pt, type)
+			if placed_peering == check_peering:
+				var tile = cache[type].front()
+				tm.set_cell(layer, c, tile[0], tile[1], tile[2])
+				changed = true
 	
 	return changed
 

--- a/addons/better-terrain/BetterTerrain.gd
+++ b/addons/better-terrain/BetterTerrain.gd
@@ -583,6 +583,22 @@ func get_tile_terrain_type(td: TileData) -> int:
 	return td_meta.type
 
 
+## Returns an Array of all [TileData] tiles included in the specified
+## terrain [code]type[/code] for the [TileSet] [code]ts[/code]
+func get_tiles_in_terrain(ts: TileSet, type: int) -> Array[TileData]:
+	var result:Array[TileData] = []
+	
+	var cache := _get_cache(ts)
+	var tiles = cache[type]
+	if tiles and tiles.size() > 0:
+		for c in tiles:
+			var source := ts.get_source(c[0]) as TileSetAtlasSource
+			var td := source.get_tile_data(c[1], c[2])
+			result.push_back(td)
+	
+	return result
+
+
 ## For a [TileSet]'s tile, specified by [TileData], add terrain [code]type[/code]
 ## (an index of a terrain) to match this tile in direction [code]peering[/code],
 ## which is of type [enum TileSet.CellNeighbor]. Returns [code]true[/code] on success.
@@ -648,6 +664,21 @@ func tile_peering_types(td: TileData, peering: int) -> Array:
 	
 	var td_meta := _get_tile_meta(td)
 	return td_meta[peering].duplicate() if td_meta.has(peering) else []
+
+
+## For the tile specified by [TileData], return the [Array] of peering directions
+## for the specified terrain type [code]type[/code].
+func tile_peering_for_type(td: TileData, type: int) -> Array:
+	if !td:
+		return []
+	
+	var td_meta := _get_tile_meta(td)
+	var result = []
+	var sides = tile_peering_keys(td)
+	for side in sides:
+		if td_meta[side].has(type):
+			result.push_back(side)
+	return result
 
 
 # Painting

--- a/addons/better-terrain/editor/Dock.gd
+++ b/addons/better-terrain/editor/Dock.gd
@@ -88,6 +88,9 @@ func _ready() -> void:
 	add_child(terrain_undo)
 	tile_view.undo_manager = undo_manager
 	tile_view.terrain_undo = terrain_undo
+	
+	tile_view.connect("paste_occurred", _on_paste_occurred)
+	tile_view.connect("change_zoom_level", _on_change_zoom_level)
 
 
 func _get_fill_cells(target: Vector2i) -> Array:
@@ -391,11 +394,6 @@ func _on_fill_pressed() -> void:
 	fill_button.button_pressed = true
 
 
-func _on_replace_pressed() -> void:
-#	replace_button.button_pressed = not replace_button.button_pressed
-	pass
-
-
 func _on_paint_type_pressed() -> void:
 	paint_terrain.button_pressed = false
 	select_tiles.button_pressed = false
@@ -419,6 +417,16 @@ func _on_select_tiles_pressed() -> void:
 
 func _on_layer_options_item_selected(index) -> void:
 	layer = index
+
+
+func _on_paste_occurred():
+	paint_type.button_pressed = false
+	paint_terrain.button_pressed = false
+	select_tiles.button_pressed = true
+
+
+func _on_change_zoom_level(value):
+	zoom_slider.value = value
 
 
 func canvas_draw(overlay: Control) -> void:
@@ -554,6 +562,8 @@ func canvas_input(event: InputEvent) -> bool:
 		var type = selected.get_index()
 		
 		if paint_action == PaintAction.LINE:
+			# if painting as line, execution happens on release. 
+			# prevent other painting actions from running.
 			pass
 		elif draw_button.button_pressed:
 			undo_manager.create_action(tr("Draw terrain"), UndoRedo.MERGE_DISABLE, tilemap)
@@ -596,7 +606,6 @@ func canvas_mouse_exit() -> void:
 
 
 func _shortcut_input(event) -> void:
-#	print_debug(event)
 	if event is InputEventKey:
 		if event.keycode == KEY_C and event.ctrl_pressed and not event.echo:
 			get_viewport().set_input_as_handled()
@@ -606,7 +615,7 @@ func _shortcut_input(event) -> void:
 			tile_view.paste_selection()
 
 
-##bersenham alg ported from Geometry2D::bresenham_line()
+## bresenham alg ported from Geometry2D::bresenham_line()
 func _get_line(from:Vector2i, to:Vector2i) -> Array[Vector2i]:
 	if from == to:
 		return [to]

--- a/addons/better-terrain/editor/Dock.gd
+++ b/addons/better-terrain/editor/Dock.gd
@@ -10,11 +10,16 @@ const TERRAIN_PROPERTIES_SCENE := preload("res://addons/better-terrain/editor/Te
 
 # Buttons
 @onready var draw_button := $VBoxContainer/Toolbar/Draw
+@onready var line_button := $VBoxContainer/Toolbar/Line
 @onready var rectangle_button := $VBoxContainer/Toolbar/Rectangle
 @onready var fill_button := $VBoxContainer/Toolbar/Fill
+@onready var replace_button := $VBoxContainer/Toolbar/Replace
 
 @onready var paint_type := $VBoxContainer/Toolbar/PaintType
 @onready var paint_terrain := $VBoxContainer/Toolbar/PaintTerrain
+@onready var select_tiles := $VBoxContainer/Toolbar/SelectTiles
+
+@onready var zoom_slider := $VBoxContainer/Toolbar/Zoom
 
 @onready var clean_button := $VBoxContainer/Toolbar/Clean
 @onready var layer_options := $VBoxContainer/Toolbar/LayerOptions
@@ -43,6 +48,7 @@ var terrain_undo
 var layer := 0
 var draw_overlay := false
 var initial_click : Vector2i
+var prev_position : Vector2i
 var current_position : Vector2i
 var tileset_dirty := false
 
@@ -52,14 +58,23 @@ enum PaintMode {
 	ERASE
 }
 
+enum PaintAction {
+	NO_ACTION,
+	LINE
+}
+
 var paint_mode := PaintMode.NO_PAINT
+
+var paint_action := PaintAction.NO_ACTION
 
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
 	draw_button.icon = get_theme_icon("Edit", "EditorIcons")
+	line_button.icon = get_theme_icon("Line", "EditorIcons")
 	rectangle_button.icon = get_theme_icon("Rectangle", "EditorIcons")
 	fill_button.icon = get_theme_icon("Bucket", "EditorIcons")
+	select_tiles.icon = get_theme_icon("ToolSelect", "EditorIcons")
 	add_terrain_button.icon = get_theme_icon("Add", "EditorIcons")
 	edit_terrain_button.icon = get_theme_icon("Tools", "EditorIcons")
 	move_up_button.icon = get_theme_icon("ArrowUp", "EditorIcons")
@@ -350,30 +365,63 @@ func perform_edit_terrain(index: int, name: String, color: Color, type: int, cat
 
 func _on_draw_pressed() -> void:
 	draw_button.button_pressed = true
+	line_button.button_pressed = false
 	rectangle_button.button_pressed = false
 	fill_button.button_pressed = false
+	replace_button.button_pressed = false
+
+
+func _on_line_pressed() -> void:
+	draw_button.button_pressed = false
+	line_button.button_pressed = true
+	rectangle_button.button_pressed = false
+	fill_button.button_pressed = false
+	replace_button.button_pressed = false
 
 
 func _on_rectangle_pressed() -> void:
 	draw_button.button_pressed = false
+	line_button.button_pressed = false
 	rectangle_button.button_pressed = true
 	fill_button.button_pressed = false
+	replace_button.button_pressed = false
 
 
 func _on_fill_pressed() -> void:
 	draw_button.button_pressed = false
+	line_button.button_pressed = false
 	rectangle_button.button_pressed = false
 	fill_button.button_pressed = true
+	replace_button.button_pressed = false
+
+
+func _on_replace_pressed() -> void:
+	draw_button.button_pressed = false
+	line_button.button_pressed = false
+	rectangle_button.button_pressed = false
+	fill_button.button_pressed = false
+	replace_button.button_pressed = true
 
 
 func _on_paint_type_pressed() -> void:
 	paint_terrain.button_pressed = false
+	select_tiles.button_pressed = false
 	tile_view.paint_mode = tile_view.PaintMode.PAINT_TYPE if paint_type.button_pressed else tile_view.PaintMode.NO_PAINT
+	tile_view.queue_redraw()
 
 
 func _on_paint_terrain_pressed() -> void:
 	paint_type.button_pressed = false
+	select_tiles.button_pressed = false
 	tile_view.paint_mode = tile_view.PaintMode.PAINT_PEERING if paint_terrain.button_pressed else tile_view.PaintMode.NO_PAINT
+	tile_view.queue_redraw()
+
+
+func _on_select_tiles_pressed() -> void:
+	paint_terrain.button_pressed = false
+	paint_type.button_pressed = false
+	tile_view.paint_mode = tile_view.PaintMode.SELECT if select_tiles.button_pressed else tile_view.PaintMode.NO_PAINT
+	tile_view.queue_redraw()
 
 
 func _on_layer_options_item_selected(index) -> void:
@@ -413,6 +461,12 @@ func canvas_draw(overlay: Control) -> void:
 		for y in range(area.position.y, area.end.y + 1):
 			for x in range(area.position.x, area.end.x + 1):
 				tiles.append(Vector2i(x, y))
+	elif paint_action == PaintAction.LINE and paint_mode != PaintMode.NO_PAINT:
+		var cells := _get_line(initial_click, current_position)
+		var shape = BetterTerrain.data.cell_polygon(tileset)
+		for c in cells:
+			var tile_transform := Transform2D(0.0, tilemap.tile_set.tile_size, 0.0, tilemap.map_to_local(c))
+			overlay.draw_colored_polygon(transform * tile_transform * shape, Color(terrain.color, 0.5))
 	elif fill_button.button_pressed:
 		tiles = _get_fill_cells(current_position)
 		if tiles.size() > MAX_CANVAS_RENDER_TILES:
@@ -436,16 +490,16 @@ func canvas_input(event: InputEvent) -> bool:
 		var tr := tilemap.get_viewport_transform() * tilemap.global_transform
 		var pos := tr.affine_inverse() * Vector2(event.position)
 		var event_position := tilemap.local_to_map(pos)
+		prev_position = current_position
 		if event_position == current_position:
 			return false
 		current_position = event_position
 		update_overlay.emit()
 	
 	if event is InputEventMouseButton and !event.pressed:
+		var type = selected.get_index()
 		if rectangle_button.button_pressed and paint_mode != PaintMode.NO_PAINT:
-			var type = selected.get_index()
 			var area := Rect2i(initial_click, current_position - initial_click).abs()
-			
 			# Fill from initial_target to target
 			undo_manager.create_action(tr("Draw terrain rectangle"), UndoRedo.MERGE_DISABLE, tilemap)
 			for y in range(area.position.y, area.end.y + 1):
@@ -460,13 +514,30 @@ func canvas_input(event: InputEvent) -> bool:
 			terrain_undo.create_tile_restore_point_area(undo_manager, tilemap, layer, area)
 			undo_manager.commit_action()
 			update_overlay.emit()
-			
+		elif PaintAction.LINE and paint_mode != PaintMode.NO_PAINT:
+			undo_manager.create_action(tr("Draw terrain line"), UndoRedo.MERGE_DISABLE, tilemap)
+			var cells := _get_line(initial_click, current_position)
+			if paint_mode == PaintMode.PAINT:
+				undo_manager.add_do_method(BetterTerrain, &"set_cells", tilemap, layer, cells, type)
+			elif paint_mode == PaintMode.ERASE:
+				for c in cells:
+					undo_manager.add_do_method(tilemap, &"erase_cell", layer, c)
+			undo_manager.add_do_method(BetterTerrain, &"update_terrain_cells", tilemap, layer, cells)
+			terrain_undo.create_tile_restore_point(undo_manager, tilemap, layer, cells)
+			undo_manager.commit_action()
+			update_overlay.emit()
 		paint_mode = PaintMode.NO_PAINT
 		return true
 	
 	var clicked : bool = event is InputEventMouseButton and event.pressed
+	var shift : bool = event.shift_pressed
 	if clicked:
 		paint_mode = PaintMode.NO_PAINT
+		
+		if (draw_button.button_pressed and shift) or line_button.button_pressed:
+			paint_action = PaintAction.LINE
+		else:
+			paint_action = PaintAction.NO_ACTION
 		
 		if event.button_index == MOUSE_BUTTON_LEFT:
 			paint_mode = PaintMode.PAINT
@@ -480,14 +551,18 @@ func canvas_input(event: InputEvent) -> bool:
 			initial_click = current_position
 		var type = selected.get_index()
 		
-		if draw_button.button_pressed:
+		if paint_action == PaintAction.LINE:
+			pass
+		elif draw_button.button_pressed:
 			undo_manager.create_action(tr("Draw terrain"), UndoRedo.MERGE_DISABLE, tilemap)
+			var cells := _get_line(prev_position, current_position)
 			if paint_mode == PaintMode.PAINT:
-				undo_manager.add_do_method(BetterTerrain, &"set_cell", tilemap, layer, current_position, type)
+				undo_manager.add_do_method(BetterTerrain, &"set_cells", tilemap, layer, cells, type)
 			elif paint_mode == PaintMode.ERASE:
-				undo_manager.add_do_method(tilemap, &"erase_cell", layer, current_position)
-			undo_manager.add_do_method(BetterTerrain, &"update_terrain_cell", tilemap, layer, current_position)
-			terrain_undo.create_tile_restore_point(undo_manager, tilemap, layer, [current_position])
+				for c in cells:
+					undo_manager.add_do_method(tilemap, &"erase_cell", layer, c)
+			undo_manager.add_do_method(BetterTerrain, &"update_terrain_cells", tilemap, layer, cells)
+			terrain_undo.create_tile_restore_point(undo_manager, tilemap, layer, cells)
 			undo_manager.commit_action()
 		elif fill_button.button_pressed:
 			var cells := _get_fill_cells(current_position)
@@ -500,6 +575,29 @@ func canvas_input(event: InputEvent) -> bool:
 			undo_manager.add_do_method(BetterTerrain, &"update_terrain_cells", tilemap, layer, cells)
 			terrain_undo.create_tile_restore_point(undo_manager, tilemap, layer, cells)
 			undo_manager.commit_action()
+		elif replace_button.button_pressed:
+			undo_manager.create_action(tr("Replace terrain"), UndoRedo.MERGE_DISABLE, tilemap)
+			var cells := _get_line(prev_position, current_position)
+			var changed = false
+			if paint_mode == PaintMode.PAINT:
+				var potential_tiles = BetterTerrain.get_tiles_in_terrain(tileset, type)
+				for c in cells:
+					var td = tilemap.get_cell_tile_data(layer, c)
+					if td:
+						var placed_peering = BetterTerrain.tile_peering_for_type(td, type)
+						if not placed_peering.is_empty():
+							for pt in potential_tiles:
+								var check_peering = BetterTerrain.tile_peering_for_type(pt, type)
+								if placed_peering == check_peering:
+									undo_manager.add_do_method(BetterTerrain, &"set_cell", tilemap, layer, c, type)
+									changed = true
+			
+			elif paint_mode == PaintMode.ERASE:
+				pass
+			if changed:
+				undo_manager.add_do_method(BetterTerrain, &"update_terrain_cells", tilemap, layer, cells)
+				terrain_undo.create_tile_restore_point(undo_manager, tilemap, layer, cells)
+			undo_manager.commit_action()
 		
 		update_overlay.emit()
 		return true
@@ -510,3 +608,47 @@ func canvas_input(event: InputEvent) -> bool:
 func canvas_mouse_exit() -> void:
 	draw_overlay = false
 	update_overlay.emit()
+
+
+func _shortcut_input(event) -> void:
+#	print_debug(event)
+	if event is InputEventKey:
+		if event.keycode == KEY_C and event.ctrl_pressed and not event.echo:
+			get_viewport().set_input_as_handled()
+			tile_view.copy_selection()
+		if event.keycode == KEY_V and event.ctrl_pressed and not event.echo:
+			get_viewport().set_input_as_handled()
+			tile_view.paste_selection()
+
+
+##bersenham alg ported from Geometry2D::bresenham_line()
+func _get_line(from:Vector2i, to:Vector2i) -> Array[Vector2i]:
+	if from == to:
+		return [to]
+	
+	var points:Array[Vector2i] = []
+	var delta := (to - from).abs() * 2
+	var step := (to - from).sign()
+	var current := from
+	
+	if delta.x > delta.y:
+		var err:int = delta.x / 2
+		while current.x != to.x:
+			points.push_back(current);
+			err -= delta.y
+			if err < 0:
+				current.y += step.y
+				err += delta.x
+			current.x += step.x
+	else:
+		var err:int = delta.y / 2
+		while current.y != to.y:
+			points.push_back(current)
+			err -= delta.x
+			if err < 0:
+				current.x += step.x
+				err += delta.y
+			current.y += step.y
+	
+	points.push_back(current);
+	return points;

--- a/addons/better-terrain/editor/Dock.gd
+++ b/addons/better-terrain/editor/Dock.gd
@@ -514,7 +514,7 @@ func canvas_input(event: InputEvent) -> bool:
 			terrain_undo.create_tile_restore_point_area(undo_manager, tilemap, layer, area)
 			undo_manager.commit_action()
 			update_overlay.emit()
-		elif PaintAction.LINE and paint_mode != PaintMode.NO_PAINT:
+		elif paint_action == PaintAction.LINE and paint_mode != PaintMode.NO_PAINT:
 			undo_manager.create_action(tr("Draw terrain line"), UndoRedo.MERGE_DISABLE, tilemap)
 			var cells := _get_line(initial_click, current_position)
 			if paint_mode == PaintMode.PAINT:
@@ -526,6 +526,7 @@ func canvas_input(event: InputEvent) -> bool:
 			terrain_undo.create_tile_restore_point(undo_manager, tilemap, layer, cells)
 			undo_manager.commit_action()
 			update_overlay.emit()
+		
 		paint_mode = PaintMode.NO_PAINT
 		return true
 	

--- a/addons/better-terrain/editor/Dock.tscn
+++ b/addons/better-terrain/editor/Dock.tscn
@@ -7,7 +7,7 @@
 [ext_resource type="Texture2D" uid="uid://c0ii3ju7iesf4" path="res://addons/better-terrain/icons/Warning.svg" id="4_6ahwe"]
 [ext_resource type="Script" path="res://addons/better-terrain/editor/TileView.gd" id="4_nqppq"]
 
-[sub_resource type="Image" id="Image_ihkrt"]
+[sub_resource type="Image" id="Image_2g1h3"]
 data = {
 "data": PackedByteArray(255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 93, 93, 41, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 44, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 44, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 94, 94, 234, 255, 95, 95, 43, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 94, 94, 234, 255, 95, 95, 43, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0),
 "format": "RGBA8",
@@ -16,8 +16,8 @@ data = {
 "width": 16
 }
 
-[sub_resource type="ImageTexture" id="ImageTexture_37lex"]
-image = SubResource("Image_ihkrt")
+[sub_resource type="ImageTexture" id="ImageTexture_ksqtf"]
+image = SubResource("Image_2g1h3")
 
 [node name="Dock" type="Control" node_paths=PackedStringArray("shortcut_context")]
 custom_minimum_size = Vector2(0, 100)
@@ -47,28 +47,28 @@ layout_mode = 2
 tooltip_text = "Draw terrain"
 toggle_mode = true
 button_pressed = true
-icon = SubResource("ImageTexture_37lex")
+icon = SubResource("ImageTexture_ksqtf")
 flat = true
 
 [node name="Line" type="Button" parent="VBoxContainer/Toolbar"]
 layout_mode = 2
 tooltip_text = "Draw line"
 toggle_mode = true
-icon = SubResource("ImageTexture_37lex")
+icon = SubResource("ImageTexture_ksqtf")
 flat = true
 
 [node name="Rectangle" type="Button" parent="VBoxContainer/Toolbar"]
 layout_mode = 2
 tooltip_text = "Fill a rectangle of terrain"
 toggle_mode = true
-icon = SubResource("ImageTexture_37lex")
+icon = SubResource("ImageTexture_ksqtf")
 flat = true
 
 [node name="Fill" type="Button" parent="VBoxContainer/Toolbar"]
 layout_mode = 2
 tooltip_text = "Bucket fill terrain"
 toggle_mode = true
-icon = SubResource("ImageTexture_37lex")
+icon = SubResource("ImageTexture_ksqtf")
 flat = true
 
 [node name="Replace" type="Button" parent="VBoxContainer/Toolbar"]
@@ -84,7 +84,7 @@ layout_mode = 2
 layout_mode = 2
 tooltip_text = "Select"
 toggle_mode = true
-icon = SubResource("ImageTexture_37lex")
+icon = SubResource("ImageTexture_ksqtf")
 flat = true
 
 [node name="PaintType" type="Button" parent="VBoxContainer/Toolbar"]
@@ -154,31 +154,31 @@ size_flags_horizontal = 3
 [node name="AddTerrain" type="Button" parent="VBoxContainer/HSplitContainer/VBoxContainer/LowerToolbar"]
 layout_mode = 2
 tooltip_text = "Add terrain type"
-icon = SubResource("ImageTexture_37lex")
+icon = SubResource("ImageTexture_ksqtf")
 flat = true
 
 [node name="EditTerrain" type="Button" parent="VBoxContainer/HSplitContainer/VBoxContainer/LowerToolbar"]
 layout_mode = 2
 tooltip_text = "Edit terrain type"
-icon = SubResource("ImageTexture_37lex")
+icon = SubResource("ImageTexture_ksqtf")
 flat = true
 
 [node name="MoveUp" type="Button" parent="VBoxContainer/HSplitContainer/VBoxContainer/LowerToolbar"]
 layout_mode = 2
 tooltip_text = "Move selected terrain up"
-icon = SubResource("ImageTexture_37lex")
+icon = SubResource("ImageTexture_ksqtf")
 flat = true
 
 [node name="MoveDown" type="Button" parent="VBoxContainer/HSplitContainer/VBoxContainer/LowerToolbar"]
 layout_mode = 2
 tooltip_text = "Move selected terrain down"
-icon = SubResource("ImageTexture_37lex")
+icon = SubResource("ImageTexture_ksqtf")
 flat = true
 
 [node name="RemoveTerrain" type="Button" parent="VBoxContainer/HSplitContainer/VBoxContainer/LowerToolbar"]
 layout_mode = 2
 tooltip_text = "Remove selected terrain type(s)"
-icon = SubResource("ImageTexture_37lex")
+icon = SubResource("ImageTexture_ksqtf")
 flat = true
 
 [node name="Panel" type="Panel" parent="VBoxContainer/HSplitContainer"]
@@ -208,7 +208,6 @@ script = ExtResource("4_nqppq")
 [connection signal="pressed" from="VBoxContainer/Toolbar/Line" to="." method="_on_line_pressed"]
 [connection signal="pressed" from="VBoxContainer/Toolbar/Rectangle" to="." method="_on_rectangle_pressed"]
 [connection signal="pressed" from="VBoxContainer/Toolbar/Fill" to="." method="_on_fill_pressed"]
-[connection signal="pressed" from="VBoxContainer/Toolbar/Replace" to="." method="_on_replace_pressed"]
 [connection signal="pressed" from="VBoxContainer/Toolbar/SelectTiles" to="." method="_on_select_tiles_pressed"]
 [connection signal="pressed" from="VBoxContainer/Toolbar/PaintType" to="." method="_on_paint_type_pressed"]
 [connection signal="pressed" from="VBoxContainer/Toolbar/PaintTerrain" to="." method="_on_paint_terrain_pressed"]

--- a/addons/better-terrain/editor/Dock.tscn
+++ b/addons/better-terrain/editor/Dock.tscn
@@ -7,7 +7,7 @@
 [ext_resource type="Texture2D" uid="uid://c0ii3ju7iesf4" path="res://addons/better-terrain/icons/Warning.svg" id="4_6ahwe"]
 [ext_resource type="Script" path="res://addons/better-terrain/editor/TileView.gd" id="4_nqppq"]
 
-[sub_resource type="Image" id="Image_fnfno"]
+[sub_resource type="Image" id="Image_ihkrt"]
 data = {
 "data": PackedByteArray(255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 93, 93, 41, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 44, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 44, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 94, 94, 234, 255, 95, 95, 43, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 94, 94, 234, 255, 95, 95, 43, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0),
 "format": "RGBA8",
@@ -16,8 +16,8 @@ data = {
 "width": 16
 }
 
-[sub_resource type="ImageTexture" id="ImageTexture_h5b0e"]
-image = SubResource("Image_fnfno")
+[sub_resource type="ImageTexture" id="ImageTexture_37lex"]
+image = SubResource("Image_ihkrt")
 
 [node name="Dock" type="Control" node_paths=PackedStringArray("shortcut_context")]
 custom_minimum_size = Vector2(0, 100)
@@ -47,45 +47,44 @@ layout_mode = 2
 tooltip_text = "Draw terrain"
 toggle_mode = true
 button_pressed = true
-icon = SubResource("ImageTexture_h5b0e")
+icon = SubResource("ImageTexture_37lex")
 flat = true
 
 [node name="Line" type="Button" parent="VBoxContainer/Toolbar"]
 layout_mode = 2
-tooltip_text = "Draw terrain"
+tooltip_text = "Draw line"
 toggle_mode = true
-icon = SubResource("ImageTexture_h5b0e")
+icon = SubResource("ImageTexture_37lex")
 flat = true
 
 [node name="Rectangle" type="Button" parent="VBoxContainer/Toolbar"]
 layout_mode = 2
 tooltip_text = "Fill a rectangle of terrain"
 toggle_mode = true
-icon = SubResource("ImageTexture_h5b0e")
+icon = SubResource("ImageTexture_37lex")
 flat = true
 
 [node name="Fill" type="Button" parent="VBoxContainer/Toolbar"]
 layout_mode = 2
 tooltip_text = "Bucket fill terrain"
 toggle_mode = true
-icon = SubResource("ImageTexture_h5b0e")
+icon = SubResource("ImageTexture_37lex")
 flat = true
 
 [node name="Replace" type="Button" parent="VBoxContainer/Toolbar"]
 layout_mode = 2
-tooltip_text = "Bucket fill terrain"
+tooltip_text = "Toggle replace mode"
 toggle_mode = true
 icon = ExtResource("2_fvmt6")
-flat = true
 
 [node name="VSeparator" type="VSeparator" parent="VBoxContainer/Toolbar"]
 layout_mode = 2
 
 [node name="SelectTiles" type="Button" parent="VBoxContainer/Toolbar"]
 layout_mode = 2
-tooltip_text = "Bucket fill terrain"
+tooltip_text = "Select"
 toggle_mode = true
-icon = SubResource("ImageTexture_h5b0e")
+icon = SubResource("ImageTexture_37lex")
 flat = true
 
 [node name="PaintType" type="Button" parent="VBoxContainer/Toolbar"]
@@ -155,31 +154,31 @@ size_flags_horizontal = 3
 [node name="AddTerrain" type="Button" parent="VBoxContainer/HSplitContainer/VBoxContainer/LowerToolbar"]
 layout_mode = 2
 tooltip_text = "Add terrain type"
-icon = SubResource("ImageTexture_h5b0e")
+icon = SubResource("ImageTexture_37lex")
 flat = true
 
 [node name="EditTerrain" type="Button" parent="VBoxContainer/HSplitContainer/VBoxContainer/LowerToolbar"]
 layout_mode = 2
 tooltip_text = "Edit terrain type"
-icon = SubResource("ImageTexture_h5b0e")
+icon = SubResource("ImageTexture_37lex")
 flat = true
 
 [node name="MoveUp" type="Button" parent="VBoxContainer/HSplitContainer/VBoxContainer/LowerToolbar"]
 layout_mode = 2
 tooltip_text = "Move selected terrain up"
-icon = SubResource("ImageTexture_h5b0e")
+icon = SubResource("ImageTexture_37lex")
 flat = true
 
 [node name="MoveDown" type="Button" parent="VBoxContainer/HSplitContainer/VBoxContainer/LowerToolbar"]
 layout_mode = 2
 tooltip_text = "Move selected terrain down"
-icon = SubResource("ImageTexture_h5b0e")
+icon = SubResource("ImageTexture_37lex")
 flat = true
 
 [node name="RemoveTerrain" type="Button" parent="VBoxContainer/HSplitContainer/VBoxContainer/LowerToolbar"]
 layout_mode = 2
 tooltip_text = "Remove selected terrain type(s)"
-icon = SubResource("ImageTexture_h5b0e")
+icon = SubResource("ImageTexture_37lex")
 flat = true
 
 [node name="Panel" type="Panel" parent="VBoxContainer/HSplitContainer"]

--- a/addons/better-terrain/editor/Dock.tscn
+++ b/addons/better-terrain/editor/Dock.tscn
@@ -1,24 +1,25 @@
-[gd_scene load_steps=8 format=3 uid="uid://de8b6h6ieal7r"]
+[gd_scene load_steps=9 format=3 uid="uid://de8b6h6ieal7r"]
 
 [ext_resource type="Script" path="res://addons/better-terrain/editor/Dock.gd" id="1_raoha"]
-[ext_resource type="Texture2D" uid="uid://c6lxq2y7mpb18" path="res://addons/better-terrain/icons/EditType.svg" id="2_cpm2t"]
-[ext_resource type="Texture2D" uid="uid://bo2cjv08jkvf8" path="res://addons/better-terrain/icons/EditTerrain.svg" id="3_pqb1p"]
-[ext_resource type="Texture2D" uid="uid://b0es228gfcykd" path="res://addons/better-terrain/icons/Warning.svg" id="4_6ahwe"]
+[ext_resource type="Texture2D" uid="uid://c0p2y7oyy1hxk" path="res://addons/better-terrain/icons/EditType.svg" id="2_cpm2t"]
+[ext_resource type="Texture2D" uid="uid://xvh28rmqyux" path="res://addons/better-terrain/icons/Replace.svg" id="2_fvmt6"]
+[ext_resource type="Texture2D" uid="uid://d2tolup0vv1e4" path="res://addons/better-terrain/icons/EditTerrain.svg" id="3_pqb1p"]
+[ext_resource type="Texture2D" uid="uid://c0ii3ju7iesf4" path="res://addons/better-terrain/icons/Warning.svg" id="4_6ahwe"]
 [ext_resource type="Script" path="res://addons/better-terrain/editor/TileView.gd" id="4_nqppq"]
 
-[sub_resource type="Image" id="Image_pjjqy"]
+[sub_resource type="Image" id="Image_fnfno"]
 data = {
-"data": PackedByteArray(255, 255, 255, 0, 255, 255, 255, 0, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 131, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 131, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 131, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 231, 255, 93, 93, 55, 255, 97, 97, 58, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 93, 93, 41, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 97, 97, 42, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 98, 98, 47, 255, 97, 97, 42, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 93, 93, 233, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 94, 94, 46, 255, 93, 93, 236, 255, 93, 93, 233, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0),
+"data": PackedByteArray(255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 93, 93, 41, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 44, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 44, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 94, 94, 234, 255, 95, 95, 43, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 94, 94, 234, 255, 95, 95, 43, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0),
 "format": "RGBA8",
 "height": 16,
 "mipmaps": false,
 "width": 16
 }
 
-[sub_resource type="ImageTexture" id="ImageTexture_lv2dr"]
-image = SubResource("Image_pjjqy")
+[sub_resource type="ImageTexture" id="ImageTexture_h5b0e"]
+image = SubResource("Image_fnfno")
 
-[node name="Dock" type="Control"]
+[node name="Dock" type="Control" node_paths=PackedStringArray("shortcut_context")]
 custom_minimum_size = Vector2(0, 100)
 layout_mode = 3
 anchors_preset = 15
@@ -26,6 +27,8 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+focus_mode = 2
+shortcut_context = NodePath(".")
 script = ExtResource("1_raoha")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
@@ -44,25 +47,46 @@ layout_mode = 2
 tooltip_text = "Draw terrain"
 toggle_mode = true
 button_pressed = true
-icon = SubResource("ImageTexture_lv2dr")
+icon = SubResource("ImageTexture_h5b0e")
+flat = true
+
+[node name="Line" type="Button" parent="VBoxContainer/Toolbar"]
+layout_mode = 2
+tooltip_text = "Draw terrain"
+toggle_mode = true
+icon = SubResource("ImageTexture_h5b0e")
 flat = true
 
 [node name="Rectangle" type="Button" parent="VBoxContainer/Toolbar"]
 layout_mode = 2
 tooltip_text = "Fill a rectangle of terrain"
 toggle_mode = true
-icon = SubResource("ImageTexture_lv2dr")
+icon = SubResource("ImageTexture_h5b0e")
 flat = true
 
 [node name="Fill" type="Button" parent="VBoxContainer/Toolbar"]
 layout_mode = 2
 tooltip_text = "Bucket fill terrain"
 toggle_mode = true
-icon = SubResource("ImageTexture_lv2dr")
+icon = SubResource("ImageTexture_h5b0e")
+flat = true
+
+[node name="Replace" type="Button" parent="VBoxContainer/Toolbar"]
+layout_mode = 2
+tooltip_text = "Bucket fill terrain"
+toggle_mode = true
+icon = ExtResource("2_fvmt6")
 flat = true
 
 [node name="VSeparator" type="VSeparator" parent="VBoxContainer/Toolbar"]
 layout_mode = 2
+
+[node name="SelectTiles" type="Button" parent="VBoxContainer/Toolbar"]
+layout_mode = 2
+tooltip_text = "Bucket fill terrain"
+toggle_mode = true
+icon = SubResource("ImageTexture_h5b0e")
+flat = true
 
 [node name="PaintType" type="Button" parent="VBoxContainer/Toolbar"]
 layout_mode = 2
@@ -131,31 +155,31 @@ size_flags_horizontal = 3
 [node name="AddTerrain" type="Button" parent="VBoxContainer/HSplitContainer/VBoxContainer/LowerToolbar"]
 layout_mode = 2
 tooltip_text = "Add terrain type"
-icon = SubResource("ImageTexture_lv2dr")
+icon = SubResource("ImageTexture_h5b0e")
 flat = true
 
 [node name="EditTerrain" type="Button" parent="VBoxContainer/HSplitContainer/VBoxContainer/LowerToolbar"]
 layout_mode = 2
 tooltip_text = "Edit terrain type"
-icon = SubResource("ImageTexture_lv2dr")
+icon = SubResource("ImageTexture_h5b0e")
 flat = true
 
 [node name="MoveUp" type="Button" parent="VBoxContainer/HSplitContainer/VBoxContainer/LowerToolbar"]
 layout_mode = 2
 tooltip_text = "Move selected terrain up"
-icon = SubResource("ImageTexture_lv2dr")
+icon = SubResource("ImageTexture_h5b0e")
 flat = true
 
 [node name="MoveDown" type="Button" parent="VBoxContainer/HSplitContainer/VBoxContainer/LowerToolbar"]
 layout_mode = 2
 tooltip_text = "Move selected terrain down"
-icon = SubResource("ImageTexture_lv2dr")
+icon = SubResource("ImageTexture_h5b0e")
 flat = true
 
 [node name="RemoveTerrain" type="Button" parent="VBoxContainer/HSplitContainer/VBoxContainer/LowerToolbar"]
 layout_mode = 2
 tooltip_text = "Remove selected terrain type(s)"
-icon = SubResource("ImageTexture_lv2dr")
+icon = SubResource("ImageTexture_h5b0e")
 flat = true
 
 [node name="Panel" type="Panel" parent="VBoxContainer/HSplitContainer"]
@@ -178,11 +202,15 @@ custom_minimum_size = Vector2(512, 512)
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
+focus_mode = 2
 script = ExtResource("4_nqppq")
 
 [connection signal="pressed" from="VBoxContainer/Toolbar/Draw" to="." method="_on_draw_pressed"]
+[connection signal="pressed" from="VBoxContainer/Toolbar/Line" to="." method="_on_line_pressed"]
 [connection signal="pressed" from="VBoxContainer/Toolbar/Rectangle" to="." method="_on_rectangle_pressed"]
 [connection signal="pressed" from="VBoxContainer/Toolbar/Fill" to="." method="_on_fill_pressed"]
+[connection signal="pressed" from="VBoxContainer/Toolbar/Replace" to="." method="_on_replace_pressed"]
+[connection signal="pressed" from="VBoxContainer/Toolbar/SelectTiles" to="." method="_on_select_tiles_pressed"]
 [connection signal="pressed" from="VBoxContainer/Toolbar/PaintType" to="." method="_on_paint_type_pressed"]
 [connection signal="pressed" from="VBoxContainer/Toolbar/PaintTerrain" to="." method="_on_paint_terrain_pressed"]
 [connection signal="value_changed" from="VBoxContainer/Toolbar/Zoom" to="VBoxContainer/HSplitContainer/Panel/ScrollArea/TileView" method="_on_zoom_value_changed"]

--- a/addons/better-terrain/editor/TileView.gd
+++ b/addons/better-terrain/editor/TileView.gd
@@ -2,6 +2,7 @@
 extends Control
 
 @onready var checkerboard := get_theme_icon("Checkerboard", "EditorIcons")
+@onready var dock = $"../../../../.."
 
 var tileset: TileSet
 
@@ -10,8 +11,20 @@ var highlighted_tile_part := { valid = false }
 var zoom_level := 1.0
 
 var tiles_size : Vector2
+var tile_size : Vector2i
+var tile_part_size : Vector2
 var alternate_size : Vector2
 var alternate_lookup := []
+var initial_click : Vector2i
+var prev_position : Vector2i
+var current_position : Vector2i
+
+var selection_start : Vector2i
+var selection_end : Vector2i
+var selection_rect : Rect2i
+var selected_tile_states : Array[Dictionary] = []
+var copied_tile_states : Array[Dictionary] = []
+var staged_paste_tile_states : Array[Dictionary] = []
 
 var undo_manager : EditorUndoRedoManager
 var terrain_undo
@@ -20,7 +33,9 @@ var terrain_undo
 enum PaintMode {
 	NO_PAINT,
 	PAINT_TYPE,
-	PAINT_PEERING
+	PAINT_PEERING,
+	SELECT,
+	PASTE
 }
 
 var paint_mode := PaintMode.NO_PAINT
@@ -31,7 +46,9 @@ enum PaintAction {
 	DRAW_TYPE,
 	ERASE_TYPE,
 	DRAW_PEERING,
-	ERASE_PEERING
+	ERASE_PEERING,
+	SELECT,
+	PASTE
 }
 
 var paint_action := PaintAction.NO_ACTION
@@ -56,6 +73,9 @@ func refresh_tileset(ts: TileSet) -> void:
 		
 		tiles_size.x = max(tiles_size.x, source.texture.get_width())
 		tiles_size.y += source.texture.get_height()
+		
+		tile_size = source.get_tile_texture_region(Vector2i.ZERO, 0).size
+		tile_part_size = Vector2(tile_size) / 3.0
 		
 		for t in source.get_tiles_count():
 			var coord := source.get_tile_id(t)
@@ -86,13 +106,13 @@ func _build_tile_part_from_position(result: Dictionary, position: Vector2i, rect
 	var type := BetterTerrain.get_tile_terrain_type(result.data)
 	if type == -1:
 		return
+	result.terrain_type = type
 	
 	var normalize_position := (Vector2(position) - rect.position) / rect.size
 	
 	var terrain := BetterTerrain.get_terrain(tileset, type)
 	if !terrain.valid:
 		return
-	
 	for p in BetterTerrain.data.get_terrain_peering_cells(tileset, terrain.type):
 		var side_polygon = BetterTerrain.data.peering_polygon(tileset, terrain.type, p)
 		if Geometry2D.is_point_in_polygon(normalize_position, side_polygon):
@@ -166,7 +186,109 @@ func tile_part_from_position(position: Vector2i) -> Dictionary:
 	return { valid = false }
 
 
-func _draw_tile_data(texture: Texture2D, rect: Rect2, src_rect: Rect2, td: TileData) -> void:
+func tile_rect_from_position(position: Vector2i) -> Rect2:
+	if !tileset:
+		return Rect2(-1,-1,0,0)
+	
+	var offset := Vector2.ZERO
+	var alt_offset := Vector2.RIGHT * (zoom_level * tiles_size.x + ALTERNATE_TILE_MARGIN)
+	if Rect2(alt_offset, zoom_level * alternate_size).has_point(position):
+		for a in alternate_lookup:
+			var next_offset_y = alt_offset.y + zoom_level * a[0].y
+			if position.y > next_offset_y:
+				alt_offset.y = next_offset_y
+				continue
+			
+			var source := tileset.get_source(a[1]) as TileSetAtlasSource
+			if !source:
+				break
+			
+			var count := source.get_alternative_tiles_count(a[2])
+			var index := int((position.x - alt_offset.x) / (zoom_level * a[0].x)) + 1
+			
+			if index < count:
+				var target_rect := Rect2(
+					alt_offset + Vector2.RIGHT * (index - 1) * zoom_level * a[0].x,
+					zoom_level * a[0]
+				)
+				return target_rect
+	
+	else:
+		for s in tileset.get_source_count():
+			var source_id := tileset.get_source_id(s)
+			var source := tileset.get_source(source_id) as TileSetAtlasSource
+			if !source:
+				continue
+			for t in source.get_tiles_count():
+				var coord := source.get_tile_id(t)
+				var rect := source.get_tile_texture_region(coord, 0)
+				var target_rect := Rect2(offset + zoom_level * rect.position, zoom_level * rect.size)
+				if target_rect.has_point(position):
+					return target_rect
+			
+			offset.y += zoom_level * source.texture.get_height()
+	
+	return Rect2(-1,-1,0,0)
+
+
+#func get_tiles_in_rect(rect:Rect2i) -> Array[Vector2i]:
+func tile_parts_from_rect(rect:Rect2) -> Array[Dictionary]:
+	if !tileset:
+		return []
+	
+	var tiles:Array[Dictionary] = []
+	
+	var offset := Vector2.ZERO
+	var alt_offset := Vector2.RIGHT * (zoom_level * tiles_size.x + ALTERNATE_TILE_MARGIN)
+	for s in tileset.get_source_count():
+		var source_id := tileset.get_source_id(s)
+		var source := tileset.get_source(source_id) as TileSetAtlasSource
+		if !source:
+			continue
+		for t in source.get_tiles_count():
+			var coord := source.get_tile_id(t)
+			var tile_rect := source.get_tile_texture_region(coord, 0)
+			var target_rect := Rect2(offset + zoom_level * tile_rect.position, zoom_level * tile_rect.size)
+			if target_rect.intersects(rect):
+				var result := {
+					valid = true,
+					source_id = source_id,
+					coord = coord,
+					alternate = 0,
+					data = source.get_tile_data(coord, 0)
+				}
+				var pos = target_rect.position + target_rect.size/2
+				_build_tile_part_from_position(result, pos, target_rect)
+				tiles.push_back(result)
+			var alt_count := source.get_alternative_tiles_count(coord)
+			for a in alt_count:
+				var alt_id := 0
+				if a == 0:
+					continue
+				else:
+					target_rect = Rect2(alt_offset + zoom_level * (a - 1) * tile_rect.size.x * Vector2.RIGHT, zoom_level * tile_rect.size)
+					alt_id = source.get_alternative_tile_id(coord, a)
+				if target_rect.intersects(rect):
+					var td := source.get_tile_data(coord, alt_id)
+					var result := {
+						valid = true,
+						source_id = source_id,
+						coord = coord,
+						alternate = alt_id,
+						data = td
+					}
+					var pos = target_rect.position + target_rect.size/2
+					_build_tile_part_from_position(result, pos, target_rect)
+					tiles.push_back(result)
+			if alt_count > 1:
+				alt_offset.y += zoom_level * tile_rect.size.y
+		
+		offset.y += zoom_level * source.texture.get_height()
+	
+	return tiles
+
+
+func _draw_tile_data(texture: Texture2D, rect: Rect2, src_rect: Rect2, td: TileData, draw_sides: bool = true) -> void:
 	var flipped_rect := rect
 	if td.flip_h:
 		flipped_rect.size.x = -rect.size.x
@@ -190,11 +312,12 @@ func _draw_tile_data(texture: Texture2D, rect: Rect2, src_rect: Rect2, td: TileD
 	if paint < 0 or paint >= BetterTerrain.terrain_count(tileset):
 		return
 	
-	var paint_terrain := BetterTerrain.get_terrain(tileset, paint)
-	for p in BetterTerrain.data.get_terrain_peering_cells(tileset, terrain.type):
-		if paint in BetterTerrain.tile_peering_types(td, p):
-			var side_polygon = BetterTerrain.data.peering_polygon(tileset, terrain.type, p)
-			draw_colored_polygon(transform * side_polygon, Color(paint_terrain.color, 0.6))
+	if draw_sides:
+		var paint_terrain := BetterTerrain.get_terrain(tileset, paint)
+		for p in BetterTerrain.data.get_terrain_peering_cells(tileset, terrain.type):
+			if paint in BetterTerrain.tile_peering_types(td, p):
+				var side_polygon = BetterTerrain.data.peering_polygon(tileset, terrain.type, p)
+				draw_colored_polygon(transform * side_polygon, Color(paint_terrain.color, 0.6))
 
 
 func _draw() -> void:
@@ -225,6 +348,16 @@ func _draw() -> void:
 					alt_id = source.get_alternative_tile_id(coord, a)
 				var td := source.get_tile_data(coord, alt_id)
 				_draw_tile_data(source.texture, target_rect, rect, td)
+				
+				if BetterTerrain.get_tile_terrain_type(td) == paint:
+					draw_rect(target_rect.grow(-1), Color(0,0,0, 0.75), false, 1)
+					draw_rect(target_rect, Color(1,1,1, 0.75), false, 1)
+				
+				if paint_mode == PaintMode.SELECT:
+					if selected_tile_states.any(func(v):
+						return v.part.data == td
+						):
+						draw_rect(target_rect.grow(-1), Color.DEEP_SKY_BLUE, false, 2)
 			
 			if alt_count > 1:
 				alt_offset.y += zoom_level * rect.size.y
@@ -263,77 +396,250 @@ func _draw() -> void:
 		if paint_mode != PaintMode.NO_PAINT:
 			var inner_rect := Rect2(highlighted_tile_part.rect.position + Vector2.ONE, highlighted_tile_part.rect.size - 2 * Vector2.ONE) 
 			draw_rect(inner_rect, Color.WHITE, false)
+	if paint_mode == PaintMode.SELECT:
+		draw_rect(selection_rect, Color.WHITE, false)
+	if paint_mode == PaintMode.PASTE:
+		if staged_paste_tile_states.size() > 0:
+			var base_rect = staged_paste_tile_states[0].base_rect
+			var paint_terrain := BetterTerrain.get_terrain(tileset, paint)
+			var paint_terrain_type = paint_terrain.type
+			if paint_terrain_type == BetterTerrain.TerrainType.CATEGORY:
+				paint_terrain_type = 0
+			for state in staged_paste_tile_states:
+				var staged_rect:Rect2 = state.base_rect
+				staged_rect.position -= base_rect.position + base_rect.size / 2
+				
+				staged_rect.position *= zoom_level
+				staged_rect.size *= zoom_level
+				
+				staged_rect.position += Vector2(current_position)
+				
+				var real_rect = tile_rect_from_position(staged_rect.get_center())
+				if real_rect.position.x >= 0:
+					draw_rect(real_rect, Color(0,0,0, 0.3), true)
+					var transform := Transform2D(0.0, real_rect.size, 0.0, real_rect.position)
+					var tile_sides = BetterTerrain.data.get_terrain_peering_cells(tileset, paint_terrain_type)
+					for p in tile_sides:
+						if state.paint in BetterTerrain.tile_peering_types(state.part.data, p):
+							var side_polygon = BetterTerrain.data.peering_polygon(tileset, paint_terrain_type, p)
+							var color = Color(paint_terrain.color, 0.6)
+							draw_colored_polygon(transform * side_polygon, color)
+				
+				draw_rect(staged_rect, Color.DEEP_PINK, false)
+
+
+func delete_selection():
+	undo_manager.create_action("Delete tile terrain peering types", UndoRedo.MERGE_DISABLE, tileset)
+	for t in selected_tile_states:
+		for side in range(16):
+			var old_peering = BetterTerrain.tile_peering_types(t.part.data, side)
+			if old_peering.has(paint):
+				undo_manager.add_do_method(BetterTerrain, &"remove_tile_peering_type", tileset, t.part.data, side, paint)
+				undo_manager.add_undo_method(BetterTerrain, &"add_tile_peering_type", tileset, t.part.data, side, paint)
+			
+	undo_manager.add_do_method(self, &"queue_redraw")
+	undo_manager.add_undo_method(self, &"queue_redraw")
+	undo_manager.commit_action()
+
+func copy_selection():
+	copied_tile_states = selected_tile_states
+
+func paste_selection():
+	staged_paste_tile_states = copied_tile_states
+	selected_tile_states = []
+	paint_mode = PaintMode.PASTE
+	paint_action = PaintAction.PASTE
+	dock.paint_type.button_pressed = false
+	dock.paint_terrain.button_pressed = false
+	dock.select_tiles.button_pressed = true
+	queue_redraw()
 
 
 func _gui_input(event) -> void:
-	if event is InputEventMouseButton and !event.pressed:
+	if event is InputEventKey:
+		if event.keycode == KEY_DELETE and not event.echo:
+			accept_event()
+			delete_selection()
+		if event.keycode == KEY_ESCAPE and not event.echo:
+			accept_event()
+			if paint_action == PaintAction.PASTE:
+				staged_paste_tile_states = []
+				paint_mode = PaintMode.SELECT
+				paint_action = PaintAction.NO_ACTION
+				selection_start = Vector2i(-1,-1)
+		if event.keycode == KEY_C and event.ctrl_pressed and not event.echo:
+			accept_event()
+			copy_selection()
+		if event.keycode == KEY_X and event.ctrl_pressed and not event.echo:
+			accept_event()
+			copy_selection()
+			delete_selection()
+		if event.keycode == KEY_V and event.ctrl_pressed and not event.echo:
+			accept_event()
+			paste_selection()
+	if event is InputEventMouseButton:
+		if event.button_index == MOUSE_BUTTON_WHEEL_UP and event.ctrl_pressed:
+			accept_event()
+			dock.zoom_slider.value *= 1.1
+		if event.button_index == MOUSE_BUTTON_WHEEL_DOWN and event.ctrl_pressed:
+			accept_event()
+			dock.zoom_slider.value /= 1.1
+	
+	var released : bool = event is InputEventMouseButton and (not event.pressed and (event.button_index == MOUSE_BUTTON_LEFT or event.button_index == MOUSE_BUTTON_RIGHT))
+	if released:
 		paint_action = PaintAction.NO_ACTION
 	
 	if event is InputEventMouseMotion:
+		prev_position = current_position
+		current_position = event.position
 		var tile := tile_part_from_position(event.position)
 		if tile.valid != highlighted_tile_part.valid or\
 			(tile.valid and tile.data != highlighted_tile_part.data) or\
-			(tile.valid and tile.get("peering") != highlighted_tile_part.get("peering")):
+			(tile.valid and tile.get("peering") != highlighted_tile_part.get("peering")) or\
+			event.button_mask & MOUSE_BUTTON_LEFT and paint_action == PaintAction.SELECT:
 			queue_redraw()
 		highlighted_tile_part = tile
 	
-	var clicked : bool = event is InputEventMouseButton and event.pressed
+	var clicked : bool = event is InputEventMouseButton and (event.pressed and (event.button_index == MOUSE_BUTTON_LEFT or event.button_index == MOUSE_BUTTON_RIGHT))
+	if clicked:
+		initial_click = current_position
+		selection_start = Vector2i(-1,-1)
+	if released:
+		selection_rect = Rect2i(0,0,0,0)
+		queue_redraw()
+	
+	if paint_action == PaintAction.PASTE:
+		if event is InputEventMouseMotion:
+			queue_redraw()
+		
+		if clicked:
+			if event.button_index == MOUSE_BUTTON_LEFT:
+				if staged_paste_tile_states.size() > 0:
+					undo_manager.create_action("Paste tile terrain peering types", UndoRedo.MERGE_DISABLE, tileset)
+					var base_rect = staged_paste_tile_states[0].base_rect
+					for p in staged_paste_tile_states:
+						var staged_rect:Rect2 = p.base_rect
+						staged_rect.position -= base_rect.position + base_rect.size / 2
+						
+						staged_rect.position *= zoom_level
+						staged_rect.size *= zoom_level
+						
+						staged_rect.position += Vector2(current_position)
+						
+						var old_tile_part = tile_part_from_position(staged_rect.get_center())
+						var new_tile_state = p
+						if old_tile_part.valid and new_tile_state.part.valid:
+							for side in range(16): #not sure how to loop over or get max value of an enum like TileSet.CellNeighbor
+								var old_peering = BetterTerrain.tile_peering_types(old_tile_part.data, side)
+								var new_sides = new_tile_state.sides
+								if old_peering.has(paint) != new_sides.has(side):
+									if new_sides.has(side):
+										undo_manager.add_do_method(BetterTerrain, &"add_tile_peering_type", tileset, old_tile_part.data, side, paint)
+										undo_manager.add_undo_method(BetterTerrain, &"remove_tile_peering_type", tileset, old_tile_part.data, side, paint)
+									else:
+										undo_manager.add_do_method(BetterTerrain, &"remove_tile_peering_type", tileset, old_tile_part.data, side, paint)
+										undo_manager.add_undo_method(BetterTerrain, &"add_tile_peering_type", tileset, old_tile_part.data, side, paint)
+									
+					undo_manager.add_do_method(self, &"queue_redraw")
+					undo_manager.add_undo_method(self, &"queue_redraw")
+					undo_manager.commit_action()
+			
+			staged_paste_tile_states = []
+			paint_mode = PaintMode.SELECT
+			paint_action = PaintAction.SELECT
+		return
+	
 	if paint >= 0 and clicked:
 		paint_action = PaintAction.NO_ACTION
-		if !highlighted_tile_part.valid:
-			return
-		
-		match [paint_mode, event.button_index]:
-			[PaintMode.PAINT_TYPE, MOUSE_BUTTON_LEFT]: paint_action = PaintAction.DRAW_TYPE
-			[PaintMode.PAINT_TYPE, MOUSE_BUTTON_RIGHT]: paint_action = PaintAction.ERASE_TYPE
-			[PaintMode.PAINT_PEERING, MOUSE_BUTTON_LEFT]: paint_action = PaintAction.DRAW_PEERING
-			[PaintMode.PAINT_PEERING, MOUSE_BUTTON_RIGHT]: paint_action = PaintAction.ERASE_PEERING
-	
+		if highlighted_tile_part.valid:
+			match [paint_mode, event.button_index]:
+				[PaintMode.PAINT_TYPE, MOUSE_BUTTON_LEFT]: paint_action = PaintAction.DRAW_TYPE
+				[PaintMode.PAINT_TYPE, MOUSE_BUTTON_RIGHT]: paint_action = PaintAction.ERASE_TYPE
+				[PaintMode.PAINT_PEERING, MOUSE_BUTTON_LEFT]: paint_action = PaintAction.DRAW_PEERING
+				[PaintMode.PAINT_PEERING, MOUSE_BUTTON_RIGHT]: paint_action = PaintAction.ERASE_PEERING
+				[PaintMode.SELECT, MOUSE_BUTTON_LEFT]: paint_action = PaintAction.SELECT
+		else:
+			match [paint_mode, event.button_index]:
+				[PaintMode.SELECT, MOUSE_BUTTON_LEFT]: paint_action = PaintAction.SELECT
 	if (clicked or event is InputEventMouseMotion) and paint_action != PaintAction.NO_ACTION:
-		if !highlighted_tile_part.valid:
-			return
 		
-		if paint_action == PaintAction.DRAW_TYPE or paint_action == PaintAction.ERASE_TYPE:
-			var type := BetterTerrain.get_tile_terrain_type(highlighted_tile_part.data)
-			var goal := paint if paint_action == PaintAction.DRAW_TYPE else -1
-			if type != goal:
-				undo_manager.create_action("Set tile terrain type", UndoRedo.MERGE_DISABLE, tileset)
-				undo_manager.add_do_method(BetterTerrain, &"set_tile_terrain_type", tileset, highlighted_tile_part.data, goal)
-				undo_manager.add_do_method(self, &"queue_redraw")
-				if goal == -1:
-					terrain_undo.create_peering_restore_point_tile(
-						undo_manager,
-						tileset,
-						highlighted_tile_part.source_id,
-						highlighted_tile_part.coord,
-						highlighted_tile_part.alternate
-					)
-				else:
-					undo_manager.add_undo_method(BetterTerrain, &"set_tile_terrain_type", tileset, highlighted_tile_part.data, type)
-				undo_manager.add_undo_method(self, &"queue_redraw")
-				undo_manager.commit_action()
-		elif paint_action == PaintAction.DRAW_PEERING:
-			if highlighted_tile_part.has("peering"):
-				if !(paint in BetterTerrain.tile_peering_types(highlighted_tile_part.data, highlighted_tile_part.peering)):
-					undo_manager.create_action("Set tile terrain peering type", UndoRedo.MERGE_DISABLE, tileset)
-					undo_manager.add_do_method(BetterTerrain, &"add_tile_peering_type", tileset, highlighted_tile_part.data, highlighted_tile_part.peering, paint)
-					undo_manager.add_do_method(self, &"queue_redraw")
-					undo_manager.add_undo_method(BetterTerrain, &"remove_tile_peering_type", tileset, highlighted_tile_part.data, highlighted_tile_part.peering, paint)
-					undo_manager.add_undo_method(self, &"queue_redraw")
-					undo_manager.commit_action()
-		elif paint_action == PaintAction.ERASE_PEERING:
-			if highlighted_tile_part.has("peering"):
-				if paint in BetterTerrain.tile_peering_types(highlighted_tile_part.data, highlighted_tile_part.peering):
-					undo_manager.create_action("Set tile terrain peering type", UndoRedo.MERGE_DISABLE, tileset)
-					undo_manager.add_do_method(BetterTerrain, &"remove_tile_peering_type", tileset, highlighted_tile_part.data, highlighted_tile_part.peering, paint)
-					undo_manager.add_do_method(self, &"queue_redraw")
-					undo_manager.add_undo_method(BetterTerrain, &"add_tile_peering_type", tileset, highlighted_tile_part.data, highlighted_tile_part.peering, paint)
-					undo_manager.add_undo_method(self, &"queue_redraw")
-					undo_manager.commit_action()
+		if paint_action == PaintAction.SELECT:
+			if clicked:
+				selection_start = Vector2i(-1,-1)
+				queue_redraw()
+			if selection_start.x < 0:
+				selection_start = current_position
+			selection_end = current_position
+			
+			selection_rect = Rect2i(selection_start, selection_end - selection_start).abs()
+			var selected_tile_parts = tile_parts_from_rect(selection_rect)
+			selected_tile_states = []
+			for t in selected_tile_parts:
+				var state := {
+					part = t,
+					base_rect = Rect2(t.rect.position / zoom_level, t.rect.size / zoom_level),
+					paint = paint,
+					sides = BetterTerrain.tile_peering_for_type(t.data, paint)
+				}
+				selected_tile_states.push_back(state)
+		else:
+			if !highlighted_tile_part.valid:
+				return
+			#slightly crude and non-optimal but way simpler than the "correct" solution
+			var current_position_vec2 = Vector2(current_position)
+			var prev_position_vec2 = Vector2(prev_position)
+			var mouse_dist = current_position_vec2.distance_to(prev_position_vec2)
+			var step_size = (tile_part_size.x * zoom_level)
+			var steps = ceil(mouse_dist / step_size)
+			for i in range(steps):
+				var t = float(i) / steps 
+				var check_position = prev_position_vec2.lerp(current_position_vec2, t)
+				highlighted_tile_part = tile_part_from_position(check_position)
+			
+				if !highlighted_tile_part.valid:
+					continue
+				
+				if paint_action == PaintAction.DRAW_TYPE or paint_action == PaintAction.ERASE_TYPE:
+					var type := BetterTerrain.get_tile_terrain_type(highlighted_tile_part.data)
+					var goal := paint if paint_action == PaintAction.DRAW_TYPE else -1
+					if type != goal:
+						undo_manager.create_action("Set tile terrain type", UndoRedo.MERGE_DISABLE, tileset)
+						undo_manager.add_do_method(BetterTerrain, &"set_tile_terrain_type", tileset, highlighted_tile_part.data, goal)
+						undo_manager.add_do_method(self, &"queue_redraw")
+						if goal == -1:
+							terrain_undo.create_peering_restore_point_tile(
+								undo_manager,
+								tileset,
+								highlighted_tile_part.source_id,
+								highlighted_tile_part.coord,
+								highlighted_tile_part.alternate
+							)
+						else:
+							undo_manager.add_undo_method(BetterTerrain, &"set_tile_terrain_type", tileset, highlighted_tile_part.data, type)
+						undo_manager.add_undo_method(self, &"queue_redraw")
+						undo_manager.commit_action()
+				elif paint_action == PaintAction.DRAW_PEERING:
+					if highlighted_tile_part.has("peering"):
+						if !(paint in BetterTerrain.tile_peering_types(highlighted_tile_part.data, highlighted_tile_part.peering)):
+							undo_manager.create_action("Set tile terrain peering type", UndoRedo.MERGE_DISABLE, tileset)
+							undo_manager.add_do_method(BetterTerrain, &"add_tile_peering_type", tileset, highlighted_tile_part.data, highlighted_tile_part.peering, paint)
+							undo_manager.add_do_method(self, &"queue_redraw")
+							undo_manager.add_undo_method(BetterTerrain, &"remove_tile_peering_type", tileset, highlighted_tile_part.data, highlighted_tile_part.peering, paint)
+							undo_manager.add_undo_method(self, &"queue_redraw")
+							undo_manager.commit_action()
+				elif paint_action == PaintAction.ERASE_PEERING:
+					if highlighted_tile_part.has("peering"):
+						if paint in BetterTerrain.tile_peering_types(highlighted_tile_part.data, highlighted_tile_part.peering):
+							undo_manager.create_action("Set tile terrain peering type", UndoRedo.MERGE_DISABLE, tileset)
+							undo_manager.add_do_method(BetterTerrain, &"remove_tile_peering_type", tileset, highlighted_tile_part.data, highlighted_tile_part.peering, paint)
+							undo_manager.add_do_method(self, &"queue_redraw")
+							undo_manager.add_undo_method(BetterTerrain, &"add_tile_peering_type", tileset, highlighted_tile_part.data, highlighted_tile_part.peering, paint)
+							undo_manager.add_undo_method(self, &"queue_redraw")
+							undo_manager.commit_action()
 
 
 func _on_zoom_value_changed(value) -> void:
-	zoom_level = value
+	zoom_level = max(1, value)
 	custom_minimum_size.x = zoom_level * tiles_size.x
 	if alternate_size.x > 0:
 		custom_minimum_size.x += ALTERNATE_TILE_MARGIN + zoom_level * alternate_size.x

--- a/addons/better-terrain/editor/TileView.gd
+++ b/addons/better-terrain/editor/TileView.gd
@@ -534,14 +534,14 @@ func _gui_input(event) -> void:
 					for side in range(16):
 						var old_peering = BetterTerrain.tile_peering_types(old_tile_part.data, side)
 						var new_sides = new_tile_state.sides
-						if old_peering.has(paint) != new_sides.has(side):
-							if new_sides.has(side):
-								undo_manager.add_do_method(BetterTerrain, &"add_tile_peering_type", tileset, old_tile_part.data, side, paint)
-								undo_manager.add_undo_method(BetterTerrain, &"remove_tile_peering_type", tileset, old_tile_part.data, side, paint)
-							else:
-								undo_manager.add_do_method(BetterTerrain, &"remove_tile_peering_type", tileset, old_tile_part.data, side, paint)
-								undo_manager.add_undo_method(BetterTerrain, &"add_tile_peering_type", tileset, old_tile_part.data, side, paint)
-								
+						
+						if new_sides.has(side) and not old_peering.has(paint):
+							undo_manager.add_do_method(BetterTerrain, &"add_tile_peering_type", tileset, old_tile_part.data, side, paint)
+							undo_manager.add_undo_method(BetterTerrain, &"remove_tile_peering_type", tileset, old_tile_part.data, side, paint)
+						elif old_peering.has(paint) and not new_sides.has(side):
+							undo_manager.add_do_method(BetterTerrain, &"remove_tile_peering_type", tileset, old_tile_part.data, side, paint)
+							undo_manager.add_undo_method(BetterTerrain, &"add_tile_peering_type", tileset, old_tile_part.data, side, paint)
+						
 				undo_manager.add_do_method(self, &"queue_redraw")
 				undo_manager.add_undo_method(self, &"queue_redraw")
 				undo_manager.commit_action()

--- a/addons/better-terrain/icons/Replace.svg
+++ b/addons/better-terrain/icons/Replace.svg
@@ -1,0 +1,8 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="10.5" y="1.5" width="4" height="4" stroke="#D9D9D9"/>
+<rect x="1" y="10" width="5" height="5" fill="#D9D9D9"/>
+<path d="M7.5 3.5H5.5C4.39543 3.5 3.5 4.39543 3.5 5.5V6.5" stroke="#E0E0E0" stroke-linecap="square"/>
+<path d="M8.5 12.5H10.5C11.6046 12.5 12.5 11.6046 12.5 10.5V9.5" stroke="#E0E0E0" stroke-linecap="square"/>
+<path d="M10 10L12.5 7.5L15 10H10Z" fill="#E0E0E0"/>
+<path d="M6 6L3.5 8.5L1 6H6Z" fill="#E0E0E0"/>
+</svg>


### PR DESCRIPTION
Hi there!

I want to start this off by saying I love this plugin, I think it's entirely more intuitive than the built-in tilemap system. I started off learning godot with version 4.0 almost solely because of the purportedly improved tile system, and I still haven't gotten used to it. After using this plugin for only a day, I've completely grasped how to use it effectively for my needs.

I began these modifications as separate git branches, but it became too much of a hassle to manage and I ended up writing everything at once. If you would like me to split this into different PRs I can try to do so.

# Changes

### Improved painting
Painting now draws unbroken lines when moving the cursor quickly. Here are some before and after examples:

Before | After
:-------:|:-------:
![sx-858](https://github.com/Portponky/better-terrain/assets/9218934/5b65e5ca-029a-46d3-a1d3-6302d6265889) | ![sx-865](https://github.com/Portponky/better-terrain/assets/9218934/e2af573e-6824-4fc1-b23d-b7a8e41f8219)
![sx-874](https://github.com/Portponky/better-terrain/assets/9218934/b78b9e7e-c7c8-476d-916b-0d076b32b758) |![sx-872](https://github.com/Portponky/better-terrain/assets/9218934/06d2b00b-cc3b-4338-84b8-357ef94a8f18)

This also works when painting tile peering sides.
> Note: This doesn't create perfect unbroken lines with tile shapes other than square. There's an alternative algorithm that was written for the new tileset system internally that's used for other tile shapes, I'll look into implementing this later.

### Line paint tool
Selecting the Line tool, or holding Shift with the normal Paint tool active, will draw lines. This mirrors the built-in editor behavior.

![sx-878](https://github.com/Portponky/better-terrain/assets/9218934/4b70bae5-bbf4-489e-bff5-1d6d0c845079)

> Note: like with the improved painting, lines are slightly wrong with non-square tile shapes

### Overwrite painting mode
A new button to the right of the paint tools toggles "overwrite" mode. While this mode is active, drawing will only change tiles on the tilemap if there is a tile with a matching set of peering sides in the current terrain.  
This allows you to easily manage alternative tilesets, such as a tileset with slopes instead of square corners, or a tileset of alt decoration tiles.

![sx-880](https://github.com/Portponky/better-terrain/assets/9218934/bdc9f0eb-29e8-4065-95ae-e0c20cfe58f4)

### Select and Copy/Paste/Delete terrain peering
A new button on the terrain side allows you to select terrain tiles. Pressing Delete will delete the tiles' peering sides. Pressing Ctrl+C or Ctrl+X will copy or cut the tiles, and Ctrl+V will put the tiles in a staging area on your cursor. Clicking will then overwrite any peering data with that of the staged tiles that were copied.  
This allows you to easily duplicate a tileset's peering sides, for instance if you have many tilesets with the same layout, without requiring you to draw it all again.

![sx-896](https://github.com/Portponky/better-terrain/assets/9218934/97313c0e-f303-4e93-9bf4-9b6d73cc7bf5)


### Ctrl-scroll zoom keybind
You can now hold ctrl while scrolling to zoom the tileset canvas.

### More clear terrain tiles
This change puts an outline around the tiles selected for the current terrain, just to make it more clear what the current terrain tiles are without needing to look for the matching color between the tile centers and the terrain icon. You can see this change in some of the gifs above.

------

These are mostly just changes I wanted for my own sake, but I figured I should make a PR for them :)
Feel free to suggest any changes or additions! There are likely places in the code that could be improved, I tried my best to mimic the existing style and understand the internal systems.

Thanks! ❤️ 