### PR TITLE
Merge UndoRedo history for painting tiles/peering

### DIFF
--- a/addons/better-terrain/editor/Dock.gd
+++ b/addons/better-terrain/editor/Dock.gd
@@ -44,6 +44,7 @@ var tileset : TileSet
 
 var undo_manager : EditorUndoRedoManager
 var terrain_undo
+var click_index := 0
 
 var layer := 0
 var draw_overlay := false
@@ -559,6 +560,7 @@ func canvas_input(event: InputEvent) -> bool:
 	if (clicked or event is InputEventMouseMotion) and paint_mode != PaintMode.NO_PAINT:
 		if clicked:
 			initial_click = current_position
+			click_index += 1
 		var type = selected.get_index()
 		
 		if paint_action == PaintAction.LINE:
@@ -566,7 +568,7 @@ func canvas_input(event: InputEvent) -> bool:
 			# prevent other painting actions from running.
 			pass
 		elif draw_button.button_pressed:
-			undo_manager.create_action(tr("Draw terrain"), UndoRedo.MERGE_DISABLE, tilemap)
+			undo_manager.create_action(tr("Draw terrain") + str(click_index), UndoRedo.MERGE_ALL, tilemap, true)
 			var cells := _get_tileset_line(prev_position, current_position, tileset)
 			if paint_mode == PaintMode.PAINT:
 				if replace_mode:

--- a/addons/better-terrain/editor/Dock.gd
+++ b/addons/better-terrain/editor/Dock.gd
@@ -44,7 +44,8 @@ var tileset : TileSet
 
 var undo_manager : EditorUndoRedoManager
 var terrain_undo
-var click_index := 0
+var action_index := 0
+var action_count := 0
 
 var layer := 0
 var draw_overlay := false
@@ -560,7 +561,8 @@ func canvas_input(event: InputEvent) -> bool:
 	if (clicked or event is InputEventMouseMotion) and paint_mode != PaintMode.NO_PAINT:
 		if clicked:
 			initial_click = current_position
-			click_index += 1
+			action_index += 1
+			action_count = 0
 		var type = selected.get_index()
 		
 		if paint_action == PaintAction.LINE:
@@ -568,19 +570,20 @@ func canvas_input(event: InputEvent) -> bool:
 			# prevent other painting actions from running.
 			pass
 		elif draw_button.button_pressed:
-			undo_manager.create_action(tr("Draw terrain") + str(click_index), UndoRedo.MERGE_ALL, tilemap, true)
+			undo_manager.create_action(tr("Draw terrain") + str(action_index), UndoRedo.MERGE_ALL, tilemap, true)
 			var cells := _get_tileset_line(prev_position, current_position, tileset)
 			if paint_mode == PaintMode.PAINT:
 				if replace_mode:
-					undo_manager.add_do_method(BetterTerrain, &"replace_cells", tilemap, layer, cells, tileset, type)
+					terrain_undo.add_do_method([BetterTerrain, &"replace_cells", tilemap, layer, cells, tileset, type])
 				else:
-					undo_manager.add_do_method(BetterTerrain, &"set_cells", tilemap, layer, cells, type)
+					terrain_undo.add_do_method(undo_manager, BetterTerrain, &"set_cells", [tilemap, layer, cells, type], action_index, action_count)
 			elif paint_mode == PaintMode.ERASE:
 				for c in cells:
 					undo_manager.add_do_method(tilemap, &"erase_cell", layer, c)
-			undo_manager.add_do_method(BetterTerrain, &"update_terrain_cells", tilemap, layer, cells)
+			terrain_undo.add_do_method(undo_manager, BetterTerrain, &"update_terrain_cells", [tilemap, layer, cells], action_index, action_count)
 			terrain_undo.create_tile_restore_point(undo_manager, tilemap, layer, cells)
 			undo_manager.commit_action()
+			action_count += 1
 		elif fill_button.button_pressed:
 			var cells := _get_fill_cells(current_position)
 			undo_manager.create_action(tr("Fill terrain"), UndoRedo.MERGE_DISABLE, tilemap)

--- a/addons/better-terrain/editor/TerrainUndo.gd
+++ b/addons/better-terrain/editor/TerrainUndo.gd
@@ -1,6 +1,9 @@
 @tool
 extends Node
 
+var _current_action_index := 0
+var _current_action_count := 0
+
 func create_tile_restore_point(undo_manager: EditorUndoRedoManager, tm: TileMap, layer: int, cells: Array, and_surrounding_cells: bool = true) -> void:
 	if and_surrounding_cells:
 		cells = BetterTerrain._widen(tm, cells)
@@ -162,22 +165,18 @@ func restore_terrain(ts: TileSet, restore: Array) -> void:
 		BetterTerrain.set_terrain(ts, i, r.name, r.color, r.type, r.categories)
 
 
-var _cur_action_index := 0
-var _cur_action_count := 0
 func add_do_method(undo_manager: EditorUndoRedoManager, object:Object, method:StringName, args:Array, action_index:int, action_count:int):
 	var cb = func():
 		object.callv(method, args)
-	if action_index > _cur_action_index:
-		_cur_action_index = action_index
-		_cur_action_count = action_count
-	if action_count > _cur_action_count:
-		_cur_action_count = action_count
+	if action_index > _current_action_index:
+		_current_action_index = action_index
+		_current_action_count = action_count
+	if action_count > _current_action_count:
+		_current_action_count = action_count
 	
 	undo_manager.add_do_method(self, "_do_method", object, method, args, action_count)
-	pass
 
 
 func _do_method(object:Object, method:StringName, args:Array, action_count:int):
-	if action_count >= _cur_action_count:
+	if action_count >= _current_action_count:
 		object.callv(method, args)
-	pass

--- a/addons/better-terrain/editor/TerrainUndo.gd
+++ b/addons/better-terrain/editor/TerrainUndo.gd
@@ -160,3 +160,24 @@ func restore_terrain(ts: TileSet, restore: Array) -> void:
 	for i in restore.size():
 		var r = restore[i]
 		BetterTerrain.set_terrain(ts, i, r.name, r.color, r.type, r.categories)
+
+
+var _cur_action_index := 0
+var _cur_action_count := 0
+func add_do_method(undo_manager: EditorUndoRedoManager, object:Object, method:StringName, args:Array, action_index:int, action_count:int):
+	var cb = func():
+		object.callv(method, args)
+	if action_index > _cur_action_index:
+		_cur_action_index = action_index
+		_cur_action_count = action_count
+	if action_count > _cur_action_count:
+		_cur_action_count = action_count
+	
+	undo_manager.add_do_method(self, "_do_method", object, method, args, action_count)
+	pass
+
+
+func _do_method(object:Object, method:StringName, args:Array, action_count:int):
+	if action_count >= _cur_action_count:
+		object.callv(method, args)
+	pass

--- a/addons/better-terrain/editor/TileView.gd
+++ b/addons/better-terrain/editor/TileView.gd
@@ -30,6 +30,7 @@ var staged_paste_tile_states : Array[Dictionary] = []
 
 var undo_manager : EditorUndoRedoManager
 var terrain_undo
+var click_index := 0
 
 # Modes for painting
 enum PaintMode {
@@ -505,6 +506,7 @@ func _gui_input(event) -> void:
 	if clicked:
 		initial_click = current_position
 		selection_start = Vector2i(-1,-1)
+		click_index += 1
 	if released:
 		selection_rect = Rect2i(0,0,0,0)
 		queue_redraw()
@@ -605,7 +607,7 @@ func _gui_input(event) -> void:
 					var type := BetterTerrain.get_tile_terrain_type(highlighted_tile_part.data)
 					var goal := paint if paint_action == PaintAction.DRAW_TYPE else -1
 					if type != goal:
-						undo_manager.create_action("Set tile terrain type", UndoRedo.MERGE_DISABLE, tileset)
+						undo_manager.create_action("Set tile terrain type " + str(click_index), UndoRedo.MERGE_ALL, tileset, true)
 						undo_manager.add_do_method(BetterTerrain, &"set_tile_terrain_type", tileset, highlighted_tile_part.data, goal)
 						undo_manager.add_do_method(self, &"queue_redraw")
 						if goal == -1:
@@ -623,7 +625,7 @@ func _gui_input(event) -> void:
 				elif paint_action == PaintAction.DRAW_PEERING:
 					if highlighted_tile_part.has("peering"):
 						if !(paint in BetterTerrain.tile_peering_types(highlighted_tile_part.data, highlighted_tile_part.peering)):
-							undo_manager.create_action("Set tile terrain peering type", UndoRedo.MERGE_DISABLE, tileset)
+							undo_manager.create_action("Set tile terrain peering type " + str(click_index), UndoRedo.MERGE_ALL, tileset, true)
 							undo_manager.add_do_method(BetterTerrain, &"add_tile_peering_type", tileset, highlighted_tile_part.data, highlighted_tile_part.peering, paint)
 							undo_manager.add_do_method(self, &"queue_redraw")
 							undo_manager.add_undo_method(BetterTerrain, &"remove_tile_peering_type", tileset, highlighted_tile_part.data, highlighted_tile_part.peering, paint)
@@ -632,7 +634,7 @@ func _gui_input(event) -> void:
 				elif paint_action == PaintAction.ERASE_PEERING:
 					if highlighted_tile_part.has("peering"):
 						if paint in BetterTerrain.tile_peering_types(highlighted_tile_part.data, highlighted_tile_part.peering):
-							undo_manager.create_action("Set tile terrain peering type", UndoRedo.MERGE_DISABLE, tileset)
+							undo_manager.create_action("Remove tile terrain peering type " + str(click_index), UndoRedo.MERGE_ALL, tileset, true)
 							undo_manager.add_do_method(BetterTerrain, &"remove_tile_peering_type", tileset, highlighted_tile_part.data, highlighted_tile_part.peering, paint)
 							undo_manager.add_do_method(self, &"queue_redraw")
 							undo_manager.add_undo_method(BetterTerrain, &"add_tile_peering_type", tileset, highlighted_tile_part.data, highlighted_tile_part.peering, paint)

--- a/addons/better-terrain/editor/TileView.gd
+++ b/addons/better-terrain/editor/TileView.gd
@@ -30,7 +30,8 @@ var staged_paste_tile_states : Array[Dictionary] = []
 
 var undo_manager : EditorUndoRedoManager
 var terrain_undo
-var click_index := 0
+var action_index := 0
+var action_count := 0
 
 # Modes for painting
 enum PaintMode {
@@ -506,7 +507,8 @@ func _gui_input(event) -> void:
 	if clicked:
 		initial_click = current_position
 		selection_start = Vector2i(-1,-1)
-		click_index += 1
+		action_index += 1
+		action_count = 0
 	if released:
 		selection_rect = Rect2i(0,0,0,0)
 		queue_redraw()
@@ -607,9 +609,9 @@ func _gui_input(event) -> void:
 					var type := BetterTerrain.get_tile_terrain_type(highlighted_tile_part.data)
 					var goal := paint if paint_action == PaintAction.DRAW_TYPE else -1
 					if type != goal:
-						undo_manager.create_action("Set tile terrain type " + str(click_index), UndoRedo.MERGE_ALL, tileset, true)
-						undo_manager.add_do_method(BetterTerrain, &"set_tile_terrain_type", tileset, highlighted_tile_part.data, goal)
-						undo_manager.add_do_method(self, &"queue_redraw")
+						undo_manager.create_action("Set tile terrain type " + str(action_index), UndoRedo.MERGE_ALL, tileset, true)
+						terrain_undo.add_do_method(undo_manager, BetterTerrain, &"set_tile_terrain_type", [tileset, highlighted_tile_part.data, goal], action_index, action_count)
+						terrain_undo.add_do_method(undo_manager, self, &"queue_redraw", [], action_index, action_count)
 						if goal == -1:
 							terrain_undo.create_peering_restore_point_tile(
 								undo_manager,
@@ -622,24 +624,27 @@ func _gui_input(event) -> void:
 							undo_manager.add_undo_method(BetterTerrain, &"set_tile_terrain_type", tileset, highlighted_tile_part.data, type)
 						undo_manager.add_undo_method(self, &"queue_redraw")
 						undo_manager.commit_action()
+						action_count += 1
 				elif paint_action == PaintAction.DRAW_PEERING:
 					if highlighted_tile_part.has("peering"):
 						if !(paint in BetterTerrain.tile_peering_types(highlighted_tile_part.data, highlighted_tile_part.peering)):
-							undo_manager.create_action("Set tile terrain peering type " + str(click_index), UndoRedo.MERGE_ALL, tileset, true)
-							undo_manager.add_do_method(BetterTerrain, &"add_tile_peering_type", tileset, highlighted_tile_part.data, highlighted_tile_part.peering, paint)
-							undo_manager.add_do_method(self, &"queue_redraw")
+							undo_manager.create_action("Set tile terrain peering type " + str(action_index), UndoRedo.MERGE_ALL, tileset, true)
+							terrain_undo.add_do_method(undo_manager, BetterTerrain, &"add_tile_peering_type", [tileset, highlighted_tile_part.data, highlighted_tile_part.peering, paint], action_index, action_count)
+							terrain_undo.add_do_method(undo_manager, self, &"queue_redraw", [], action_index, action_count)
 							undo_manager.add_undo_method(BetterTerrain, &"remove_tile_peering_type", tileset, highlighted_tile_part.data, highlighted_tile_part.peering, paint)
 							undo_manager.add_undo_method(self, &"queue_redraw")
 							undo_manager.commit_action()
+							action_count += 1
 				elif paint_action == PaintAction.ERASE_PEERING:
 					if highlighted_tile_part.has("peering"):
 						if paint in BetterTerrain.tile_peering_types(highlighted_tile_part.data, highlighted_tile_part.peering):
-							undo_manager.create_action("Remove tile terrain peering type " + str(click_index), UndoRedo.MERGE_ALL, tileset, true)
-							undo_manager.add_do_method(BetterTerrain, &"remove_tile_peering_type", tileset, highlighted_tile_part.data, highlighted_tile_part.peering, paint)
-							undo_manager.add_do_method(self, &"queue_redraw")
+							undo_manager.create_action("Remove tile terrain peering type " + str(action_index), UndoRedo.MERGE_ALL, tileset, true)
+							terrain_undo.add_do_method(undo_manager, BetterTerrain, &"remove_tile_peering_type", [tileset, highlighted_tile_part.data, highlighted_tile_part.peering, paint], action_index, action_count)
+							terrain_undo.add_do_method(undo_manager, self, &"queue_redraw", [], action_index, action_count)
 							undo_manager.add_undo_method(BetterTerrain, &"add_tile_peering_type", tileset, highlighted_tile_part.data, highlighted_tile_part.peering, paint)
 							undo_manager.add_undo_method(self, &"queue_redraw")
 							undo_manager.commit_action()
+							action_count += 1
 
 
 func _on_zoom_value_changed(value) -> void:


### PR DESCRIPTION
Undo/Redo history for painting tiles or peering bits is now merged within the same stroke. Clicking, drawing a bunch, and releasing will how be undone by pressing Undo once, rather than needing to press Undo for each segment of the path drawn. (Which is especially annoying since you can't hold Ctrl+Z in Godot to repeatedly undo in the editor)

Before | After
:-------:|:-------:
![sx-911](https://github.com/Portponky/better-terrain/assets/9218934/67d6374f-d502-4fce-9aad-41ca2d77cb47) | ![sx-913](https://github.com/Portponky/better-terrain/assets/9218934/419fb1d8-fc8b-4eaa-9852-08c71ff119f4)

The `action_index` is used to organize the action names, since that's what determines how `UndoRedo` merges actions.

Note: the expected implementation of this feature causes a significant slowdown when painting tiles due to a long-standing bug in Godot: https://github.com/godotengine/godot/issues/26118
(Basically, the `do_method`s from *all* merged actions are being redundantly called each time `commit_action` is called, instead of just the set of methods from the latest action. The more tiles drawn in the same stroke, the larger the list of methods fired each frame)

I've implemented a workaround that essentially implements a proxy `add_do_method` function which keeps a reference to an incrementing counter of the function's calls, and only runs the function if the counter is at the max (basically, it ignores calls to functions it knows it already handled).

I only implemented this workaround for the tile painting section, not the peering bit section, since that has so little overhead that it doesn't cause any noticeable slowdown.