### PR TITLE
fix incorrect terrain undo calls

### DIFF
--- a/addons/better-terrain/editor/Dock.gd
+++ b/addons/better-terrain/editor/Dock.gd
@@ -533,12 +533,12 @@ func canvas_input(event: InputEvent) -> bool:
 			var cells := _get_tileset_line(prev_position, current_position, tileset)
 			if paint_mode == PaintMode.PAINT:
 				if replace_mode:
-					terrain_undo.add_do_method([BetterTerrain, &"replace_cells", tilemap, layer, cells, tileset, type])
+					terrain_undo.add_do_method(undo_manager, BetterTerrain, &"replace_cells", [tilemap, layer, cells, tileset, type], action_index, action_count)
 				else:
 					terrain_undo.add_do_method(undo_manager, BetterTerrain, &"set_cells", [tilemap, layer, cells, type], action_index, action_count)
 			elif paint_mode == PaintMode.ERASE:
 				for c in cells:
-					undo_manager.add_do_method(tilemap, &"erase_cell", layer, c)
+					terrain_undo.add_do_method(undo_manager, tilemap, &"erase_cell", [layer, c], action_index, action_count)
 			terrain_undo.add_do_method(undo_manager, BetterTerrain, &"update_terrain_cells", [tilemap, layer, cells], action_index, action_count)
 			terrain_undo.create_tile_restore_point(undo_manager, tilemap, layer, cells)
 			undo_manager.commit_action()

--- a/addons/better-terrain/editor/Dock.gd
+++ b/addons/better-terrain/editor/Dock.gd
@@ -44,8 +44,6 @@ var tileset : TileSet
 
 var undo_manager : EditorUndoRedoManager
 var terrain_undo
-var action_index := 0
-var action_count := 0
 
 var layer := 0
 var draw_overlay := false
@@ -460,7 +458,9 @@ func canvas_input(event: InputEvent) -> bool:
 	
 	var replace_mode = replace_button.button_pressed
 	
-	if event is InputEventMouseButton and !event.pressed:
+	var released : bool = event is InputEventMouseButton and !event.pressed
+	if released:
+		terrain_undo.finish_action()
 		var type = selected.get_index()
 		if rectangle_button.button_pressed and paint_mode != PaintMode.NO_PAINT:
 			var area := Rect2i(initial_click, current_position - initial_click).abs()
@@ -520,8 +520,8 @@ func canvas_input(event: InputEvent) -> bool:
 	if (clicked or event is InputEventMouseMotion) and paint_mode != PaintMode.NO_PAINT:
 		if clicked:
 			initial_click = current_position
-			action_index += 1
-			action_count = 0
+			terrain_undo.action_index += 1
+			terrain_undo.action_count = 0
 		var type = selected.get_index()
 		
 		if paint_action == PaintAction.LINE:
@@ -529,20 +529,20 @@ func canvas_input(event: InputEvent) -> bool:
 			# prevent other painting actions from running.
 			pass
 		elif draw_button.button_pressed:
-			undo_manager.create_action(tr("Draw terrain") + str(action_index), UndoRedo.MERGE_ALL, tilemap, true)
+			undo_manager.create_action(tr("Draw terrain") + str(terrain_undo.action_index), UndoRedo.MERGE_ALL, tilemap, true)
 			var cells := _get_tileset_line(prev_position, current_position, tileset)
 			if paint_mode == PaintMode.PAINT:
 				if replace_mode:
-					terrain_undo.add_do_method(undo_manager, BetterTerrain, &"replace_cells", [tilemap, layer, cells, tileset, type], action_index, action_count)
+					terrain_undo.add_do_method(undo_manager, BetterTerrain, &"replace_cells", [tilemap, layer, cells, tileset, type])
 				else:
-					terrain_undo.add_do_method(undo_manager, BetterTerrain, &"set_cells", [tilemap, layer, cells, type], action_index, action_count)
+					terrain_undo.add_do_method(undo_manager, BetterTerrain, &"set_cells", [tilemap, layer, cells, type])
 			elif paint_mode == PaintMode.ERASE:
 				for c in cells:
-					terrain_undo.add_do_method(undo_manager, tilemap, &"erase_cell", [layer, c], action_index, action_count)
-			terrain_undo.add_do_method(undo_manager, BetterTerrain, &"update_terrain_cells", [tilemap, layer, cells], action_index, action_count)
+					terrain_undo.add_do_method(undo_manager, tilemap, &"erase_cell", [layer, c])
+			terrain_undo.add_do_method(undo_manager, BetterTerrain, &"update_terrain_cells", [tilemap, layer, cells])
 			terrain_undo.create_tile_restore_point(undo_manager, tilemap, layer, cells)
 			undo_manager.commit_action()
-			action_count += 1
+			terrain_undo.action_count += 1
 		elif fill_button.button_pressed:
 			var cells := _get_fill_cells(current_position)
 			undo_manager.create_action(tr("Fill terrain"), UndoRedo.MERGE_DISABLE, tilemap)

--- a/addons/better-terrain/editor/TerrainUndo.gd
+++ b/addons/better-terrain/editor/TerrainUndo.gd
@@ -1,6 +1,8 @@
 @tool
 extends Node
 
+var action_index := 0
+var action_count := 0
 var _current_action_index := 0
 var _current_action_count := 0
 
@@ -165,18 +167,19 @@ func restore_terrain(ts: TileSet, restore: Array) -> void:
 		BetterTerrain.set_terrain(ts, i, r.name, r.color, r.type, r.categories)
 
 
-func add_do_method(undo_manager: EditorUndoRedoManager, object:Object, method:StringName, args:Array, action_index:int, action_count:int):
-	var cb = func():
-		object.callv(method, args)
+func add_do_method(undo_manager: EditorUndoRedoManager, object:Object, method:StringName, args:Array):
 	if action_index > _current_action_index:
 		_current_action_index = action_index
 		_current_action_count = action_count
 	if action_count > _current_action_count:
 		_current_action_count = action_count
-	
-	undo_manager.add_do_method(self, "_do_method", object, method, args, action_count)
+	undo_manager.add_do_method(self, "_do_method", object, method, args, action_index, action_count)
 
 
-func _do_method(object:Object, method:StringName, args:Array, action_count:int):
-	if action_count >= _current_action_count:
+func _do_method(object:Object, method:StringName, args:Array, this_action_index:int, this_action_count:int):
+	if this_action_count >= _current_action_count:
 		object.callv(method, args)
+
+
+func finish_action():
+	_current_action_count = 0

--- a/addons/better-terrain/editor/TerrainUndo.gd
+++ b/addons/better-terrain/editor/TerrainUndo.gd
@@ -173,10 +173,10 @@ func add_do_method(undo_manager: EditorUndoRedoManager, object:Object, method:St
 		_current_action_count = action_count
 	if action_count > _current_action_count:
 		_current_action_count = action_count
-	undo_manager.add_do_method(self, "_do_method", object, method, args, action_index, action_count)
+	undo_manager.add_do_method(self, "_do_method", object, method, args, action_count)
 
 
-func _do_method(object:Object, method:StringName, args:Array, this_action_index:int, this_action_count:int):
+func _do_method(object:Object, method:StringName, args:Array, this_action_count:int):
 	if this_action_count >= _current_action_count:
 		object.callv(method, args)
 

--- a/addons/better-terrain/editor/TileView.gd
+++ b/addons/better-terrain/editor/TileView.gd
@@ -30,8 +30,6 @@ var staged_paste_tile_states : Array[Dictionary] = []
 
 var undo_manager : EditorUndoRedoManager
 var terrain_undo
-var action_index := 0
-var action_count := 0
 
 # Modes for painting
 enum PaintMode {
@@ -507,9 +505,10 @@ func _gui_input(event) -> void:
 	if clicked:
 		initial_click = current_position
 		selection_start = Vector2i(-1,-1)
-		action_index += 1
-		action_count = 0
+		terrain_undo.action_index += 1
+		terrain_undo.action_count = 0
 	if released:
+		terrain_undo.finish_action()
 		selection_rect = Rect2i(0,0,0,0)
 		queue_redraw()
 	
@@ -609,9 +608,9 @@ func _gui_input(event) -> void:
 					var type := BetterTerrain.get_tile_terrain_type(highlighted_tile_part.data)
 					var goal := paint if paint_action == PaintAction.DRAW_TYPE else -1
 					if type != goal:
-						undo_manager.create_action("Set tile terrain type " + str(action_index), UndoRedo.MERGE_ALL, tileset, true)
-						terrain_undo.add_do_method(undo_manager, BetterTerrain, &"set_tile_terrain_type", [tileset, highlighted_tile_part.data, goal], action_index, action_count)
-						terrain_undo.add_do_method(undo_manager, self, &"queue_redraw", [], action_index, action_count)
+						undo_manager.create_action("Set tile terrain type " + str(terrain_undo.action_index), UndoRedo.MERGE_ALL, tileset, true)
+						terrain_undo.add_do_method(undo_manager, BetterTerrain, &"set_tile_terrain_type", [tileset, highlighted_tile_part.data, goal])
+						terrain_undo.add_do_method(undo_manager, self, &"queue_redraw", [])
 						if goal == -1:
 							terrain_undo.create_peering_restore_point_tile(
 								undo_manager,
@@ -624,27 +623,27 @@ func _gui_input(event) -> void:
 							undo_manager.add_undo_method(BetterTerrain, &"set_tile_terrain_type", tileset, highlighted_tile_part.data, type)
 						undo_manager.add_undo_method(self, &"queue_redraw")
 						undo_manager.commit_action()
-						action_count += 1
+						terrain_undo.action_count += 1
 				elif paint_action == PaintAction.DRAW_PEERING:
 					if highlighted_tile_part.has("peering"):
 						if !(paint in BetterTerrain.tile_peering_types(highlighted_tile_part.data, highlighted_tile_part.peering)):
-							undo_manager.create_action("Set tile terrain peering type " + str(action_index), UndoRedo.MERGE_ALL, tileset, true)
-							terrain_undo.add_do_method(undo_manager, BetterTerrain, &"add_tile_peering_type", [tileset, highlighted_tile_part.data, highlighted_tile_part.peering, paint], action_index, action_count)
-							terrain_undo.add_do_method(undo_manager, self, &"queue_redraw", [], action_index, action_count)
+							undo_manager.create_action("Set tile terrain peering type " + str(terrain_undo.action_index), UndoRedo.MERGE_ALL, tileset, true)
+							terrain_undo.add_do_method(undo_manager, BetterTerrain, &"add_tile_peering_type", [tileset, highlighted_tile_part.data, highlighted_tile_part.peering, paint])
+							terrain_undo.add_do_method(undo_manager, self, &"queue_redraw", [])
 							undo_manager.add_undo_method(BetterTerrain, &"remove_tile_peering_type", tileset, highlighted_tile_part.data, highlighted_tile_part.peering, paint)
 							undo_manager.add_undo_method(self, &"queue_redraw")
 							undo_manager.commit_action()
-							action_count += 1
+							terrain_undo.action_count += 1
 				elif paint_action == PaintAction.ERASE_PEERING:
 					if highlighted_tile_part.has("peering"):
 						if paint in BetterTerrain.tile_peering_types(highlighted_tile_part.data, highlighted_tile_part.peering):
-							undo_manager.create_action("Remove tile terrain peering type " + str(action_index), UndoRedo.MERGE_ALL, tileset, true)
-							terrain_undo.add_do_method(undo_manager, BetterTerrain, &"remove_tile_peering_type", [tileset, highlighted_tile_part.data, highlighted_tile_part.peering, paint], action_index, action_count)
-							terrain_undo.add_do_method(undo_manager, self, &"queue_redraw", [], action_index, action_count)
+							undo_manager.create_action("Remove tile terrain peering type " + str(terrain_undo.action_index), UndoRedo.MERGE_ALL, tileset, true)
+							terrain_undo.add_do_method(undo_manager, BetterTerrain, &"remove_tile_peering_type", [tileset, highlighted_tile_part.data, highlighted_tile_part.peering, paint])
+							terrain_undo.add_do_method(undo_manager, self, &"queue_redraw", [])
 							undo_manager.add_undo_method(BetterTerrain, &"add_tile_peering_type", tileset, highlighted_tile_part.data, highlighted_tile_part.peering, paint)
 							undo_manager.add_undo_method(self, &"queue_redraw")
 							undo_manager.commit_action()
-							action_count += 1
+							terrain_undo.action_count += 1
 
 
 func _on_zoom_value_changed(value) -> void:


### PR DESCRIPTION
Fixes an incorrect `TerrainUndo.add_do_method` call I overlooked, and changes the erase mode to use the new TerrainUndo method.

Edit: actually, hold off on merging this. I've encountered a few other bugs regarding the undo system that I'll try to fix and add to this PR