### PR TITLE
terrain icons

### DIFF
--- a/addons/better-terrain/BetterTerrain.gd
+++ b/addons/better-terrain/BetterTerrain.gd
@@ -639,6 +639,8 @@ func get_tile_sources_in_terrain(ts: TileSet, type: int) -> Array[Dictionary]:
 		return result
 	for c in tiles:
 		var source := ts.get_source(c[0]) as TileSetAtlasSource
+		if not source:
+			continue
 		var td := source.get_tile_data(c[1], c[2])
 		result.push_back({
 			source = source,

--- a/addons/better-terrain/BetterTerrain.gd
+++ b/addons/better-terrain/BetterTerrain.gd
@@ -22,7 +22,7 @@ extends Node
 const TERRAIN_META = &"_better_terrain"
 
 ## The current version. Used to handle future upgrades.
-const TERRAIN_SYSTEM_VERSION = "0.1"
+const TERRAIN_SYSTEM_VERSION = "0.2"
 
 var _tile_cache = {}
 
@@ -181,10 +181,21 @@ func _has_invalid_peering_types(ts: TileSet) -> bool:
 
 func _update_terrain_data(ts: TileSet) -> void:
 	var ts_meta = _get_terrain_meta(ts)
-	if !ts_meta.has("version"):
+	var version = ts_meta.version if ts_meta.has("version") else "0.0"
+	var changed = false
+	if version == "0.0":
 		for t in ts_meta.terrains:
 			if t.size() == 3:
 				t.push_back([])
+		changed = true
+	
+	if float(ts_meta.version) < 0.2:
+		for t in ts_meta.terrains:
+			if t.size() == 4:
+				t.push_back({})
+		changed = true
+	
+	if changed:
 		_set_terrain_meta(ts, ts_meta)
 
 
@@ -347,7 +358,10 @@ func get_terrain_categories(ts: TileSet) -> Array:
 ## [code]type[/code] must be one of [enum TerrainType].[br]
 ## [code]categories[/code] is an indexed list of terrain categories that this terrain
 ## can match as. The indexes must be valid terrains of the CATEGORY type.
-func add_terrain(ts: TileSet, name: String, color: Color, type: int, categories: Array = []) -> bool:
+## [code]icon[/code] is a [Dictionary] with either a [code]path[/code] string pointing
+## to a resource, or a [code]source_id[/code] [int] and a [code]coord[/code] [Vector2i].
+## The former takes priority if both are present.
+func add_terrain(ts: TileSet, name: String, color: Color, type: int, categories: Array = [], icon: Dictionary = {}) -> bool:
 	if !ts or name.is_empty() or type < 0 or type >= TerrainType.MAX:
 		return false
 	
@@ -360,7 +374,10 @@ func add_terrain(ts: TileSet, name: String, color: Color, type: int, categories:
 		if c < 0 or c >= ts_meta.terrains.size() or ts_meta.terrains[c][2] != TerrainType.CATEGORY:
 			return false
 	
-	ts_meta.terrains.push_back([name, color, type, categories])
+	if icon and not (icon.has("path") or (icon.has("source_id") and icon.has("coord"))):
+		return false
+	
+	ts_meta.terrains.push_back([name, color, type, categories, icon])
 	_set_terrain_meta(ts, ts_meta)
 	_purge_cache(ts)
 	return true
@@ -439,8 +456,10 @@ func terrain_count(ts: TileSet) -> int:
 ## [br][br]
 ## Returns a [Dictionary] describing the terrain. If it succeeds, the key [code]valid[/code]
 ## will be set to [code]true[/code]. Other keys are [code]name[/code], [code]color[/code],
-## [code]type[/code] (a [enum TerrainType]), and [code]categories[/code] which is
-## an [Array] of category type terrains that this terrain matches as.
+## [code]type[/code] (a [enum TerrainType]), [code]categories[/code] which is
+## an [Array] of category type terrains that this terrain matches as, and
+## [code]icon[/code] which is a [Dictionary] with a [code]path[/code] [String] or
+## a [code]source_id[/code] [int] and [code]coord[/code] [Vector2i]
 func get_terrain(ts: TileSet, index: int) -> Dictionary:
 	if !ts or index < 0:
 		return {valid = false}
@@ -455,6 +474,7 @@ func get_terrain(ts: TileSet, index: int) -> Dictionary:
 		color = terrain[1],
 		type = terrain[2],
 		categories = terrain[3],
+		icon = terrain[4],
 		valid = true
 	}
 
@@ -464,7 +484,9 @@ func get_terrain(ts: TileSet, index: int) -> Dictionary:
 ## [br][br]
 ## If supplied, the [code]categories[/code] must be a list of indexes to other [code]CATEGORY[/code]
 ## type terrains.
-func set_terrain(ts: TileSet, index: int, name: String, color: Color, type: int, categories: Array = []) -> bool:
+## [code]icon[/code] is a [Dictionary] with either a [code]path[/code] string pointing
+## to a resource, or a [code]source_id[/code] [int] and a [code]coord[/code] [Vector2i].
+func set_terrain(ts: TileSet, index: int, name: String, color: Color, type: int, categories: Array = [], icon: Dictionary = {}) -> bool:
 	if !ts or name.is_empty() or index < 0 or type < 0 or type >= TerrainType.MAX:
 		return false
 	
@@ -478,11 +500,14 @@ func set_terrain(ts: TileSet, index: int, name: String, color: Color, type: int,
 		if c < 0 or c == index or c >= ts_meta.terrains.size() or ts_meta.terrains[c][2] != TerrainType.CATEGORY:
 			return false
 	
+	if icon and not (icon.has("path") or (icon.has("source_id") and icon.has("coord"))):
+		return false
+	
 	if type != TerrainType.CATEGORY:
 		for t in ts_meta.terrains:
 			t[3].erase(index)
 	
-	ts_meta.terrains[index] = [name, color, type, categories]
+	ts_meta.terrains[index] = [name, color, type, categories, icon]
 	_set_terrain_meta(ts, ts_meta)
 	
 	_clear_invalid_peering_types(ts)
@@ -596,6 +621,31 @@ func get_tiles_in_terrain(ts: TileSet, type: int) -> Array[TileData]:
 		var source := ts.get_source(c[0]) as TileSetAtlasSource
 		var td := source.get_tile_data(c[1], c[2])
 		result.push_back(td)
+	
+	return result
+
+
+## Returns an [Array] of [Dictionary] items including information about each 
+## tile included in the specified terrain [code]type[/code] for 
+## the [TileSet] [code]ts[/code]. Each Dictionary item includes 
+## [TileSetAtlasSource] [code]source[/code], [TileData] [code]td[/code], 
+## [Vector2i] [code]coord[/code], and [int] [code]alt_id[/code].
+func get_tile_sources_in_terrain(ts: TileSet, type: int) -> Array[Dictionary]:
+	var result:Array[Dictionary] = []
+	
+	var cache := _get_cache(ts)
+	var tiles = cache[type]
+	if !tiles:
+		return result
+	for c in tiles:
+		var source := ts.get_source(c[0]) as TileSetAtlasSource
+		var td := source.get_tile_data(c[1], c[2])
+		result.push_back({
+			source = source,
+			td = td,
+			coord = c[1],
+			alt_id = c[2]
+		})
 	
 	return result
 

--- a/addons/better-terrain/editor/Dock.gd
+++ b/addons/better-terrain/editor/Dock.gd
@@ -7,6 +7,7 @@ signal update_overlay
 # To prevent editor lag when drawing large rectangles or filling large areas
 const MAX_CANVAS_RENDER_TILES = 1500
 const TERRAIN_PROPERTIES_SCENE := preload("res://addons/better-terrain/editor/TerrainProperties.tscn")
+const TERRAIN_ENTRY_SCENE := preload("res://addons/better-terrain/editor/TerrainEntry.tscn")
 
 # Buttons
 @onready var draw_button := $VBoxContainer/Toolbar/Draw
@@ -26,12 +27,15 @@ const TERRAIN_PROPERTIES_SCENE := preload("res://addons/better-terrain/editor/Te
 
 @onready var add_terrain_button := $VBoxContainer/HSplitContainer/VBoxContainer/LowerToolbar/AddTerrain
 @onready var edit_terrain_button := $VBoxContainer/HSplitContainer/VBoxContainer/LowerToolbar/EditTerrain
+@onready var pick_icon_button := $VBoxContainer/HSplitContainer/VBoxContainer/LowerToolbar/PickIcon
 @onready var move_up_button := $VBoxContainer/HSplitContainer/VBoxContainer/LowerToolbar/MoveUp
 @onready var move_down_button := $VBoxContainer/HSplitContainer/VBoxContainer/LowerToolbar/MoveDown
 @onready var remove_terrain_button := $VBoxContainer/HSplitContainer/VBoxContainer/LowerToolbar/RemoveTerrain
 
-@onready var terrain_tree := $VBoxContainer/HSplitContainer/VBoxContainer/Panel/Tree
+@onready var terrain_list := $VBoxContainer/HSplitContainer/VBoxContainer/Panel/ScrollContainer/TerrainList
 @onready var tile_view := $VBoxContainer/HSplitContainer/Panel/ScrollArea/TileView
+
+var selected_entry := -1
 
 @onready var terrain_icons := [
 	load("res://addons/better-terrain/icons/MatchTiles.svg"),
@@ -77,14 +81,12 @@ func _ready() -> void:
 	select_tiles.icon = get_theme_icon("ToolSelect", "EditorIcons")
 	add_terrain_button.icon = get_theme_icon("Add", "EditorIcons")
 	edit_terrain_button.icon = get_theme_icon("Tools", "EditorIcons")
+	pick_icon_button.icon = get_theme_icon("ColorPick", "EditorIcons")
 	move_up_button.icon = get_theme_icon("ArrowUp", "EditorIcons")
 	move_down_button.icon = get_theme_icon("ArrowDown", "EditorIcons")
 	remove_terrain_button.icon = get_theme_icon("Remove", "EditorIcons")
 	
 	select_tiles.button_group.pressed.connect(_on_bit_button_pressed)
-	
-	# Make a root node for the terrain tree
-	terrain_tree.create_item()
 	
 	terrain_undo = load("res://addons/better-terrain/editor/TerrainUndo.gd").new()
 	add_child(terrain_undo)
@@ -93,6 +95,7 @@ func _ready() -> void:
 	
 	tile_view.paste_occurred.connect(_on_paste_occurred)
 	tile_view.change_zoom_level.connect(_on_change_zoom_level)
+	tile_view.terrain_updated.connect(_on_terrain_updated)
 
 
 func _get_fill_cells(target: Vector2i) -> Array:
@@ -129,22 +132,19 @@ func tiles_changed() -> void:
 	BetterTerrain._update_terrain_data(tileset)
 	
 	# clear terrains
-	var root = terrain_tree.get_root()
+	for c in terrain_list.get_children():
+		terrain_list.remove_child(c)
 	
 	# load terrains from tileset
 	var terrain_count := BetterTerrain.terrain_count(tileset)
 	for i in terrain_count:
 		var terrain := BetterTerrain.get_terrain(tileset, i)
-		if i >= root.get_child_count():
-			terrain_tree.create_item(root)
-		var item = root.get_child(i)
-		item.set_text(0, terrain.name)
-		item.set_icon(0, terrain_icons[terrain.type])
-		item.set_icon_modulate(0, terrain.color)
+		if i >= terrain_list.get_child_count():
+			add_terrain_entry(terrain, i)
 	
-	while terrain_count < root.get_child_count():
-		var child = root.get_child(root.get_child_count() - 1)
-		root.remove_child(child)
+	while terrain_count < terrain_list.get_child_count():
+		var child = terrain_list.get_child(terrain_list.get_child_count() - 1)
+		terrain_list.remove_child(child)
 		child.free()
 	
 	layer_options.clear()
@@ -183,6 +183,14 @@ func queue_tiles_changed() -> void:
 	call_deferred(&"tiles_changed")
 
 
+func _on_entry_select(index:int):
+	selected_entry = index
+	for i in range(terrain_list.get_child_count()):
+		if i != index:
+			terrain_list.get_child(i).set_selected(false)
+	update_tile_view_paint()
+
+
 func _on_clean_pressed() -> void:
 	var confirmed := [false]
 	var popup := ConfirmationDialog.new()
@@ -207,8 +215,7 @@ func _on_clean_pressed() -> void:
 
 
 func update_tile_view_paint() -> void:
-	var selected = terrain_tree.get_selected()
-	tile_view.paint = selected.get_index() if selected else -1
+	tile_view.paint = selected_entry
 	tile_view.queue_redraw()
 
 
@@ -226,13 +233,14 @@ func _on_add_terrain_pressed() -> void:
 	popup.set_category_data(BetterTerrain.get_terrain_categories(tileset))
 	popup.terrain_name = "New terrain"
 	popup.terrain_color = Color.from_hsv(randf(), 0.3 + 0.7 * randf(), 0.6 + 0.4 * randf())
+	popup.terrain_icon = ""
 	popup.terrain_type = 0
 	popup.popup_centered()
 	await popup.visibility_changed
 	if popup.accepted:
 		undo_manager.create_action("Add terrain type", UndoRedo.MERGE_DISABLE, tileset)
-		undo_manager.add_do_method(self, &"perform_add_terrain", popup.terrain_name, popup.terrain_color, popup.terrain_type, popup.terrain_categories)
-		undo_manager.add_undo_method(self, &"perform_remove_terrain", terrain_tree.get_root().get_child_count())
+		undo_manager.add_do_method(self, &"perform_add_terrain", popup.terrain_name, popup.terrain_color, popup.terrain_type, popup.terrain_categories, {path = popup.terrain_icon})
+		undo_manager.add_undo_method(self, &"perform_remove_terrain", terrain_list.get_child_count())
 		undo_manager.commit_action()
 	popup.queue_free()
 
@@ -241,46 +249,58 @@ func _on_edit_terrain_pressed() -> void:
 	if !tileset:
 		return
 	
-	var item = terrain_tree.get_selected()
-	if !item:
+	if selected_entry < 0:
 		return
-	var index = item.get_index()
 	
-	var t := BetterTerrain.get_terrain(tileset, item.get_index())
+	var t := BetterTerrain.get_terrain(tileset, selected_entry)
 	var categories = BetterTerrain.get_terrain_categories(tileset)
-	categories = categories.filter(func(x): return x.id != index)
+	categories = categories.filter(func(x): return x.id != selected_entry)
 	
 	var popup := generate_popup()
 	popup.set_category_data(categories)
 	
+	t.icon = t.icon.duplicate()
+	
 	popup.terrain_name = t.name
 	popup.terrain_type = t.type
 	popup.terrain_color = t.color
+	if t.has("icon") and t.icon.has("path"):
+		popup.terrain_icon = t.icon.path
 	popup.terrain_categories = t.categories
 	popup.popup_centered()
 	await popup.visibility_changed
 	if popup.accepted:
 		undo_manager.create_action("Edit terrain details", UndoRedo.MERGE_DISABLE, tileset)
-		undo_manager.add_do_method(self, &"perform_edit_terrain", index, popup.terrain_name, popup.terrain_color, popup.terrain_type, popup.terrain_categories)
-		undo_manager.add_undo_method(self, &"perform_edit_terrain", index, t.name, t.color, t.type, t.categories)
+		undo_manager.add_do_method(self, &"perform_edit_terrain", selected_entry, popup.terrain_name, popup.terrain_color, popup.terrain_type, popup.terrain_categories, {path = popup.terrain_icon})
+		undo_manager.add_undo_method(self, &"perform_edit_terrain", selected_entry, t.name, t.color, t.type, t.categories, t.icon)
 		if t.type != popup.terrain_type:
 			terrain_undo.create_terran_type_restore_point(undo_manager, tileset)
-			terrain_undo.create_peering_restore_point_specific(undo_manager, tileset, index)
+			terrain_undo.create_peering_restore_point_specific(undo_manager, tileset, selected_entry)
 		undo_manager.commit_action()
 	popup.queue_free()
+
+
+func _on_pick_icon_pressed():
+	if selected_entry < 0:
+		return
+	tile_view.pick_icon_terrain = selected_entry
+
+
+func _on_pick_icon_focus_exited():
+	tile_view.pick_icon_terrain_cancel = true
+	pick_icon_button.button_pressed = false
 
 
 func _on_move_pressed(down: bool) -> void:
 	if !tileset:
 		return
 	
-	var item = terrain_tree.get_selected()
-	if !item:
+	if selected_entry < 0:
 		return
 	
-	var index1 = item.get_index()
+	var index1 = selected_entry
 	var index2 = index1 + (1 if down else -1)
-	if index2 < 0 or index2 >= terrain_tree.get_root().get_child_count():
+	if index2 < 0 or index2 >= terrain_list.get_child_count():
 		return
 	
 	undo_manager.create_action("Reorder terrains", UndoRedo.MERGE_DISABLE, tileset)
@@ -293,12 +313,11 @@ func _on_remove_terrain_pressed() -> void:
 	if !tileset:
 		return
 	
-	var item = terrain_tree.get_selected()
-	if !item:
+	if selected_entry < 0:
 		return
 	
 	# store confirmation in array to pass by ref
-	var t := BetterTerrain.get_terrain(tileset, item.get_index())
+	var t := BetterTerrain.get_terrain(tileset, selected_entry)
 	var confirmed := [false]
 	var popup := ConfirmationDialog.new()
 	popup.dialog_text = tr("Are you sure you want to remove {0}?").format([t.name])
@@ -314,57 +333,74 @@ func _on_remove_terrain_pressed() -> void:
 	
 	if confirmed[0]:
 		undo_manager.create_action("Remove terrain type", UndoRedo.MERGE_DISABLE, tileset)
-		undo_manager.add_do_method(self, &"perform_remove_terrain", item.get_index())
-		undo_manager.add_undo_method(self, &"perform_add_terrain", t.name, t.color, t.type)
-		for n in range(terrain_tree.get_root().get_child_count() - 1, item.get_index(), -1):
+		undo_manager.add_do_method(self, &"perform_remove_terrain", selected_entry)
+		undo_manager.add_undo_method(self, &"perform_add_terrain", t.name, t.color, t.type, t.categories, t.icon)
+		for n in range(terrain_list.get_child_count() - 1, selected_entry, -1):
 			undo_manager.add_undo_method(self, &"perform_swap_terrain", n, n - 1)
 		if t.type == BetterTerrain.TerrainType.CATEGORY:
 			terrain_undo.create_terran_type_restore_point(undo_manager, tileset)
-		terrain_undo.create_peering_restore_point_specific(undo_manager, tileset, item.get_index())
+		terrain_undo.create_peering_restore_point_specific(undo_manager, tileset, selected_entry)
 		undo_manager.commit_action()
 
 
-func perform_add_terrain(name: String, color: Color, type: int, categories: Array) -> void:
-	if BetterTerrain.add_terrain(tileset, name, color, type, categories):
-		var new_terrain = terrain_tree.create_item(terrain_tree.get_root())
-		new_terrain.set_text(0, name)
-		new_terrain.set_icon(0, terrain_icons[type])
-		new_terrain.set_icon_modulate(0, color)
+func add_terrain_entry(terrain:Dictionary, index:int = -1):
+	if index < 0:
+		index = terrain_list.get_child_count()
+	
+	var entry = TERRAIN_ENTRY_SCENE.instantiate()
+	entry.tileset = tileset
+	entry.terrain = terrain
+	entry.select.connect(_on_entry_select)
+	
+	terrain_list.add_child(entry)
+
+
+func remove_terrain_entry(index:int):
+	terrain_list.get_child(index).free()
+
+
+func perform_add_terrain(name: String, color: Color, type: int, categories: Array, icon:Dictionary = {}) -> void:
+	if BetterTerrain.add_terrain(tileset, name, color, type, categories, icon):
+		var index = BetterTerrain.terrain_count(tileset) - 1
+		var terrain = BetterTerrain.get_terrain(tileset, index)
+		add_terrain_entry(terrain, index)
 
 
 func perform_remove_terrain(index: int) -> void:
-	var root = terrain_tree.get_root()
-	if index >= root.get_child_count():
+	if index >= terrain_list.get_child_count():
 		return
-	var item = root.get_child(index)
+	var item = terrain_list.get_child(index)
 	if BetterTerrain.remove_terrain(tileset, index):
-		item.free()
+		remove_terrain_entry(index)
 		update_tile_view_paint()
 
 
 func perform_swap_terrain(index1: int, index2: int) -> void:
 	var lower := min(index1, index2)
 	var higher := max(index1, index2)
-	var root = terrain_tree.get_root()
-	if lower >= root.get_child_count() or higher >= root.get_child_count():
+	if lower >= terrain_list.get_child_count() or higher >= terrain_list.get_child_count():
 		return
-	var item1 = root.get_child(lower)
-	var item2 = root.get_child(higher)
+	var item1 = terrain_list.get_child(lower)
+	var item2 = terrain_list.get_child(higher)
 	if BetterTerrain.swap_terrains(tileset, lower, higher):
-		item2.move_before(item1)
-		item1.move_after(root.get_child(higher))
+		terrain_list.move_child(item1, higher)
+		selected_entry = index2
+		terrain_list.get_child(index2).set_selected(true)
 		update_tile_view_paint()
 
 
-func perform_edit_terrain(index: int, name: String, color: Color, type: int, categories: Array) -> void:
-	var root = terrain_tree.get_root()
-	if index >= root.get_child_count():
+func perform_edit_terrain(index: int, name: String, color: Color, type: int, categories: Array, icon: Dictionary = {}) -> void:
+	if index >= terrain_list.get_child_count():
 		return
-	var item = root.get_child(index)
-	if BetterTerrain.set_terrain(tileset, index, name, color, type, categories):
-		item.set_text(0, name)
-		item.set_icon(0, terrain_icons[type])
-		item.set_icon_modulate(0, color)
+	var entry = terrain_list.get_child(index)
+	# don't overwrite empty icon
+	var _icon = icon
+	if icon.has("path") and icon.path.is_empty():
+		var terrain = BetterTerrain.get_terrain(tileset, index)
+		_icon = terrain.icon
+	if BetterTerrain.set_terrain(tileset, index, name, color, type, categories, _icon):
+		entry.terrain = BetterTerrain.get_terrain(tileset, index)
+		entry.update()
 		tile_view.queue_redraw()
 
 func _on_bit_button_pressed(button: BaseButton) -> void:
@@ -388,15 +424,20 @@ func _on_change_zoom_level(value):
 	zoom_slider.value = value
 
 
+func _on_terrain_updated(index):
+	var entry = terrain_list.get_child(index)
+	entry.terrain = BetterTerrain.get_terrain(tileset, index)
+	entry.update()
+
+
 func canvas_draw(overlay: Control) -> void:
 	if !draw_overlay:
 		return
 	
-	var selected = terrain_tree.get_selected()
-	if !selected:
+	if selected_entry < 0:
 		return
 	
-	var type = selected.get_index()
+	var type = selected_entry
 	var terrain := BetterTerrain.get_terrain(tileset, type)
 	if !terrain.valid:
 		return
@@ -441,8 +482,7 @@ func canvas_draw(overlay: Control) -> void:
 
 
 func canvas_input(event: InputEvent) -> bool:
-	var selected = terrain_tree.get_selected()
-	if !selected:
+	if selected_entry < 0:
 		return false
 	
 	draw_overlay = true
@@ -461,7 +501,7 @@ func canvas_input(event: InputEvent) -> bool:
 	var released : bool = event is InputEventMouseButton and !event.pressed
 	if released:
 		terrain_undo.finish_action()
-		var type = selected.get_index()
+		var type = selected_entry
 		if rectangle_button.button_pressed and paint_mode != PaintMode.NO_PAINT:
 			var area := Rect2i(initial_click, current_position - initial_click).abs()
 			# Fill from initial_target to target
@@ -522,7 +562,7 @@ func canvas_input(event: InputEvent) -> bool:
 			initial_click = current_position
 			terrain_undo.action_index += 1
 			terrain_undo.action_count = 0
-		var type = selected.get_index()
+		var type = selected_entry
 		
 		if paint_action == PaintAction.LINE:
 			# if painting as line, execution happens on release. 
@@ -665,3 +705,4 @@ func _get_tileset_line(from:Vector2i, to:Vector2i, tileset:TileSet) -> Array[Vec
 			points.push_back(Vector2i(current.y, current.x) if transposed else current)
 	
 	return points
+

--- a/addons/better-terrain/editor/Dock.gd
+++ b/addons/better-terrain/editor/Dock.gd
@@ -174,6 +174,7 @@ func tiles_changed() -> void:
 	clean_button.visible = BetterTerrain._has_invalid_peering_types(tileset)
 	
 	tileset_dirty = false
+	_on_grid_mode_pressed()
 
 
 func queue_tiles_changed() -> void:

--- a/addons/better-terrain/editor/Dock.gd
+++ b/addons/better-terrain/editor/Dock.gd
@@ -34,6 +34,7 @@ const TERRAIN_ENTRY_SCENE := preload("res://addons/better-terrain/editor/Terrain
 
 @onready var terrain_list := $VBoxContainer/HSplitContainer/VBoxContainer/Panel/ScrollContainer/TerrainList
 @onready var tile_view := $VBoxContainer/HSplitContainer/Panel/ScrollArea/TileView
+@onready var grid_mode_button := $VBoxContainer/HSplitContainer/VBoxContainer/HBoxContainer/GridMode
 
 var selected_entry := -1
 
@@ -85,6 +86,7 @@ func _ready() -> void:
 	move_up_button.icon = get_theme_icon("ArrowUp", "EditorIcons")
 	move_down_button.icon = get_theme_icon("ArrowDown", "EditorIcons")
 	remove_terrain_button.icon = get_theme_icon("Remove", "EditorIcons")
+	grid_mode_button.icon = get_theme_icon("Grid", "EditorIcons")
 	
 	select_tiles.button_group.pressed.connect(_on_bit_button_pressed)
 	
@@ -212,6 +214,12 @@ func _on_clean_pressed() -> void:
 		terrain_undo.create_peering_restore_point(undo_manager, tileset)
 		undo_manager.add_undo_method(self, &"tiles_changed")
 		undo_manager.commit_action()
+
+
+func _on_grid_mode_pressed():
+	for c in terrain_list.get_children():
+		c.grid_mode = grid_mode_button.button_pressed
+		c.update_style()
 
 
 func update_tile_view_paint() -> void:
@@ -394,11 +402,11 @@ func perform_edit_terrain(index: int, name: String, color: Color, type: int, cat
 		return
 	var entry = terrain_list.get_child(index)
 	# don't overwrite empty icon
-	var _icon = icon
+	var valid_icon = icon
 	if icon.has("path") and icon.path.is_empty():
 		var terrain = BetterTerrain.get_terrain(tileset, index)
-		_icon = terrain.icon
-	if BetterTerrain.set_terrain(tileset, index, name, color, type, categories, _icon):
+		valid_icon = terrain.icon
+	if BetterTerrain.set_terrain(tileset, index, name, color, type, categories, valid_icon):
 		entry.terrain = BetterTerrain.get_terrain(tileset, index)
 		entry.update()
 		tile_view.queue_redraw()

--- a/addons/better-terrain/editor/Dock.tscn
+++ b/addons/better-terrain/editor/Dock.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=11 format=3 uid="uid://de8b6h6ieal7r"]
+[gd_scene load_steps=12 format=3 uid="uid://de8b6h6ieal7r"]
 
 [ext_resource type="Script" path="res://addons/better-terrain/editor/Dock.gd" id="1_raoha"]
 [ext_resource type="Texture2D" uid="uid://c6lxq2y7mpb18" path="res://addons/better-terrain/icons/EditType.svg" id="2_cpm2t"]
@@ -9,7 +9,7 @@
 
 [sub_resource type="ButtonGroup" id="ButtonGroup_aon7c"]
 
-[sub_resource type="Image" id="Image_i2ml0"]
+[sub_resource type="Image" id="Image_bus6w"]
 data = {
 "data": PackedByteArray(255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 93, 93, 41, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 44, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 44, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 94, 94, 234, 255, 95, 95, 43, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 94, 94, 234, 255, 95, 95, 43, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0),
 "format": "RGBA8",
@@ -18,11 +18,14 @@ data = {
 "width": 16
 }
 
-[sub_resource type="ImageTexture" id="ImageTexture_kypbj"]
-image = SubResource("Image_i2ml0")
+[sub_resource type="ImageTexture" id="ImageTexture_kka6v"]
+image = SubResource("Image_bus6w")
 
 [sub_resource type="ButtonGroup" id="ButtonGroup_3wrxn"]
 allow_unpress = true
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_mpeb7"]
+bg_color = Color(0, 0, 0, 0.4)
 
 [node name="Dock" type="Control" node_paths=PackedStringArray("shortcut_context")]
 custom_minimum_size = Vector2(0, 100)
@@ -53,7 +56,7 @@ tooltip_text = "Draw terrain"
 toggle_mode = true
 button_pressed = true
 button_group = SubResource("ButtonGroup_aon7c")
-icon = SubResource("ImageTexture_kypbj")
+icon = SubResource("ImageTexture_kka6v")
 flat = true
 
 [node name="Line" type="Button" parent="VBoxContainer/Toolbar"]
@@ -61,7 +64,7 @@ layout_mode = 2
 tooltip_text = "Draw line"
 toggle_mode = true
 button_group = SubResource("ButtonGroup_aon7c")
-icon = SubResource("ImageTexture_kypbj")
+icon = SubResource("ImageTexture_kka6v")
 flat = true
 
 [node name="Rectangle" type="Button" parent="VBoxContainer/Toolbar"]
@@ -69,7 +72,7 @@ layout_mode = 2
 tooltip_text = "Fill a rectangle of terrain"
 toggle_mode = true
 button_group = SubResource("ButtonGroup_aon7c")
-icon = SubResource("ImageTexture_kypbj")
+icon = SubResource("ImageTexture_kka6v")
 flat = true
 
 [node name="Fill" type="Button" parent="VBoxContainer/Toolbar"]
@@ -77,7 +80,7 @@ layout_mode = 2
 tooltip_text = "Bucket fill terrain"
 toggle_mode = true
 button_group = SubResource("ButtonGroup_aon7c")
-icon = SubResource("ImageTexture_kypbj")
+icon = SubResource("ImageTexture_kka6v")
 flat = true
 
 [node name="Replace" type="Button" parent="VBoxContainer/Toolbar"]
@@ -94,7 +97,7 @@ layout_mode = 2
 tooltip_text = "Select"
 toggle_mode = true
 button_group = SubResource("ButtonGroup_3wrxn")
-icon = SubResource("ImageTexture_kypbj")
+icon = SubResource("ImageTexture_kka6v")
 flat = true
 
 [node name="PaintType" type="Button" parent="VBoxContainer/Toolbar"]
@@ -143,18 +146,19 @@ split_offset = 20
 [node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/HSplitContainer"]
 layout_mode = 2
 
-[node name="Panel" type="Panel" parent="VBoxContainer/HSplitContainer/VBoxContainer"]
+[node name="Panel" type="PanelContainer" parent="VBoxContainer/HSplitContainer/VBoxContainer"]
 layout_mode = 2
 size_flags_vertical = 3
+theme_override_styles/panel = SubResource("StyleBoxFlat_mpeb7")
 
-[node name="Tree" type="Tree" parent="VBoxContainer/HSplitContainer/VBoxContainer/Panel"]
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-hide_root = true
+[node name="ScrollContainer" type="ScrollContainer" parent="VBoxContainer/HSplitContainer/VBoxContainer/Panel"]
+layout_mode = 2
+
+[node name="TerrainList" type="VBoxContainer" parent="VBoxContainer/HSplitContainer/VBoxContainer/Panel/ScrollContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 0
+theme_override_constants/separation = 0
 
 [node name="LowerToolbar" type="HBoxContainer" parent="VBoxContainer/HSplitContainer/VBoxContainer"]
 layout_mode = 2
@@ -166,31 +170,38 @@ size_flags_horizontal = 3
 [node name="AddTerrain" type="Button" parent="VBoxContainer/HSplitContainer/VBoxContainer/LowerToolbar"]
 layout_mode = 2
 tooltip_text = "Add terrain type"
-icon = SubResource("ImageTexture_kypbj")
+icon = SubResource("ImageTexture_kka6v")
 flat = true
 
 [node name="EditTerrain" type="Button" parent="VBoxContainer/HSplitContainer/VBoxContainer/LowerToolbar"]
 layout_mode = 2
 tooltip_text = "Edit terrain type"
-icon = SubResource("ImageTexture_kypbj")
+icon = SubResource("ImageTexture_kka6v")
+flat = true
+
+[node name="PickIcon" type="Button" parent="VBoxContainer/HSplitContainer/VBoxContainer/LowerToolbar"]
+layout_mode = 2
+tooltip_text = "Pick terrain icon from tileset"
+toggle_mode = true
+icon = SubResource("ImageTexture_kka6v")
 flat = true
 
 [node name="MoveUp" type="Button" parent="VBoxContainer/HSplitContainer/VBoxContainer/LowerToolbar"]
 layout_mode = 2
 tooltip_text = "Move selected terrain up"
-icon = SubResource("ImageTexture_kypbj")
+icon = SubResource("ImageTexture_kka6v")
 flat = true
 
 [node name="MoveDown" type="Button" parent="VBoxContainer/HSplitContainer/VBoxContainer/LowerToolbar"]
 layout_mode = 2
 tooltip_text = "Move selected terrain down"
-icon = SubResource("ImageTexture_kypbj")
+icon = SubResource("ImageTexture_kka6v")
 flat = true
 
 [node name="RemoveTerrain" type="Button" parent="VBoxContainer/HSplitContainer/VBoxContainer/LowerToolbar"]
 layout_mode = 2
 tooltip_text = "Remove selected terrain type(s)"
-icon = SubResource("ImageTexture_kypbj")
+icon = SubResource("ImageTexture_kka6v")
 flat = true
 
 [node name="Panel" type="Panel" parent="VBoxContainer/HSplitContainer"]
@@ -219,9 +230,10 @@ script = ExtResource("4_nqppq")
 [connection signal="value_changed" from="VBoxContainer/Toolbar/Zoom" to="VBoxContainer/HSplitContainer/Panel/ScrollArea/TileView" method="_on_zoom_value_changed"]
 [connection signal="pressed" from="VBoxContainer/Toolbar/Clean" to="." method="_on_clean_pressed"]
 [connection signal="item_selected" from="VBoxContainer/Toolbar/LayerOptions" to="." method="_on_layer_options_item_selected"]
-[connection signal="cell_selected" from="VBoxContainer/HSplitContainer/VBoxContainer/Panel/Tree" to="." method="update_tile_view_paint"]
 [connection signal="pressed" from="VBoxContainer/HSplitContainer/VBoxContainer/LowerToolbar/AddTerrain" to="." method="_on_add_terrain_pressed"]
 [connection signal="pressed" from="VBoxContainer/HSplitContainer/VBoxContainer/LowerToolbar/EditTerrain" to="." method="_on_edit_terrain_pressed"]
+[connection signal="focus_exited" from="VBoxContainer/HSplitContainer/VBoxContainer/LowerToolbar/PickIcon" to="." method="_on_pick_icon_focus_exited"]
+[connection signal="pressed" from="VBoxContainer/HSplitContainer/VBoxContainer/LowerToolbar/PickIcon" to="." method="_on_pick_icon_pressed"]
 [connection signal="pressed" from="VBoxContainer/HSplitContainer/VBoxContainer/LowerToolbar/MoveUp" to="." method="_on_move_pressed" binds= [false]]
 [connection signal="pressed" from="VBoxContainer/HSplitContainer/VBoxContainer/LowerToolbar/MoveDown" to="." method="_on_move_pressed" binds= [true]]
 [connection signal="pressed" from="VBoxContainer/HSplitContainer/VBoxContainer/LowerToolbar/RemoveTerrain" to="." method="_on_remove_terrain_pressed"]

--- a/addons/better-terrain/editor/Dock.tscn
+++ b/addons/better-terrain/editor/Dock.tscn
@@ -9,7 +9,7 @@
 
 [sub_resource type="ButtonGroup" id="ButtonGroup_aon7c"]
 
-[sub_resource type="Image" id="Image_bus6w"]
+[sub_resource type="Image" id="Image_uq87e"]
 data = {
 "data": PackedByteArray(255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 93, 93, 41, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 44, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 44, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 94, 94, 234, 255, 95, 95, 43, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 94, 94, 234, 255, 95, 95, 43, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0),
 "format": "RGBA8",
@@ -18,8 +18,8 @@ data = {
 "width": 16
 }
 
-[sub_resource type="ImageTexture" id="ImageTexture_kka6v"]
-image = SubResource("Image_bus6w")
+[sub_resource type="ImageTexture" id="ImageTexture_v7rem"]
+image = SubResource("Image_uq87e")
 
 [sub_resource type="ButtonGroup" id="ButtonGroup_3wrxn"]
 allow_unpress = true
@@ -56,7 +56,7 @@ tooltip_text = "Draw terrain"
 toggle_mode = true
 button_pressed = true
 button_group = SubResource("ButtonGroup_aon7c")
-icon = SubResource("ImageTexture_kka6v")
+icon = SubResource("ImageTexture_v7rem")
 flat = true
 
 [node name="Line" type="Button" parent="VBoxContainer/Toolbar"]
@@ -64,7 +64,7 @@ layout_mode = 2
 tooltip_text = "Draw line"
 toggle_mode = true
 button_group = SubResource("ButtonGroup_aon7c")
-icon = SubResource("ImageTexture_kka6v")
+icon = SubResource("ImageTexture_v7rem")
 flat = true
 
 [node name="Rectangle" type="Button" parent="VBoxContainer/Toolbar"]
@@ -72,7 +72,7 @@ layout_mode = 2
 tooltip_text = "Fill a rectangle of terrain"
 toggle_mode = true
 button_group = SubResource("ButtonGroup_aon7c")
-icon = SubResource("ImageTexture_kka6v")
+icon = SubResource("ImageTexture_v7rem")
 flat = true
 
 [node name="Fill" type="Button" parent="VBoxContainer/Toolbar"]
@@ -80,7 +80,7 @@ layout_mode = 2
 tooltip_text = "Bucket fill terrain"
 toggle_mode = true
 button_group = SubResource("ButtonGroup_aon7c")
-icon = SubResource("ImageTexture_kka6v")
+icon = SubResource("ImageTexture_v7rem")
 flat = true
 
 [node name="Replace" type="Button" parent="VBoxContainer/Toolbar"]
@@ -97,7 +97,7 @@ layout_mode = 2
 tooltip_text = "Select"
 toggle_mode = true
 button_group = SubResource("ButtonGroup_3wrxn")
-icon = SubResource("ImageTexture_kka6v")
+icon = SubResource("ImageTexture_v7rem")
 flat = true
 
 [node name="PaintType" type="Button" parent="VBoxContainer/Toolbar"]
@@ -141,10 +141,21 @@ layout_mode = 2
 [node name="HSplitContainer" type="HSplitContainer" parent="VBoxContainer"]
 layout_mode = 2
 size_flags_vertical = 3
-split_offset = 20
+split_offset = 325
 
 [node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/HSplitContainer"]
 layout_mode = 2
+
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/HSplitContainer/VBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 8
+
+[node name="GridMode" type="Button" parent="VBoxContainer/HSplitContainer/VBoxContainer/HBoxContainer"]
+layout_mode = 2
+tooltip_text = "Toggle grid view"
+toggle_mode = true
+icon = SubResource("ImageTexture_v7rem")
+flat = true
 
 [node name="Panel" type="PanelContainer" parent="VBoxContainer/HSplitContainer/VBoxContainer"]
 layout_mode = 2
@@ -153,12 +164,12 @@ theme_override_styles/panel = SubResource("StyleBoxFlat_mpeb7")
 
 [node name="ScrollContainer" type="ScrollContainer" parent="VBoxContainer/HSplitContainer/VBoxContainer/Panel"]
 layout_mode = 2
+horizontal_scroll_mode = 3
 
-[node name="TerrainList" type="VBoxContainer" parent="VBoxContainer/HSplitContainer/VBoxContainer/Panel/ScrollContainer"]
+[node name="TerrainList" type="HFlowContainer" parent="VBoxContainer/HSplitContainer/VBoxContainer/Panel/ScrollContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
-size_flags_vertical = 0
-theme_override_constants/separation = 0
+size_flags_vertical = 3
 
 [node name="LowerToolbar" type="HBoxContainer" parent="VBoxContainer/HSplitContainer/VBoxContainer"]
 layout_mode = 2
@@ -170,38 +181,38 @@ size_flags_horizontal = 3
 [node name="AddTerrain" type="Button" parent="VBoxContainer/HSplitContainer/VBoxContainer/LowerToolbar"]
 layout_mode = 2
 tooltip_text = "Add terrain type"
-icon = SubResource("ImageTexture_kka6v")
+icon = SubResource("ImageTexture_v7rem")
 flat = true
 
 [node name="EditTerrain" type="Button" parent="VBoxContainer/HSplitContainer/VBoxContainer/LowerToolbar"]
 layout_mode = 2
 tooltip_text = "Edit terrain type"
-icon = SubResource("ImageTexture_kka6v")
+icon = SubResource("ImageTexture_v7rem")
 flat = true
 
 [node name="PickIcon" type="Button" parent="VBoxContainer/HSplitContainer/VBoxContainer/LowerToolbar"]
 layout_mode = 2
 tooltip_text = "Pick terrain icon from tileset"
 toggle_mode = true
-icon = SubResource("ImageTexture_kka6v")
+icon = SubResource("ImageTexture_v7rem")
 flat = true
 
 [node name="MoveUp" type="Button" parent="VBoxContainer/HSplitContainer/VBoxContainer/LowerToolbar"]
 layout_mode = 2
 tooltip_text = "Move selected terrain up"
-icon = SubResource("ImageTexture_kka6v")
+icon = SubResource("ImageTexture_v7rem")
 flat = true
 
 [node name="MoveDown" type="Button" parent="VBoxContainer/HSplitContainer/VBoxContainer/LowerToolbar"]
 layout_mode = 2
 tooltip_text = "Move selected terrain down"
-icon = SubResource("ImageTexture_kka6v")
+icon = SubResource("ImageTexture_v7rem")
 flat = true
 
 [node name="RemoveTerrain" type="Button" parent="VBoxContainer/HSplitContainer/VBoxContainer/LowerToolbar"]
 layout_mode = 2
 tooltip_text = "Remove selected terrain type(s)"
-icon = SubResource("ImageTexture_kka6v")
+icon = SubResource("ImageTexture_v7rem")
 flat = true
 
 [node name="Panel" type="Panel" parent="VBoxContainer/HSplitContainer"]
@@ -230,6 +241,7 @@ script = ExtResource("4_nqppq")
 [connection signal="value_changed" from="VBoxContainer/Toolbar/Zoom" to="VBoxContainer/HSplitContainer/Panel/ScrollArea/TileView" method="_on_zoom_value_changed"]
 [connection signal="pressed" from="VBoxContainer/Toolbar/Clean" to="." method="_on_clean_pressed"]
 [connection signal="item_selected" from="VBoxContainer/Toolbar/LayerOptions" to="." method="_on_layer_options_item_selected"]
+[connection signal="pressed" from="VBoxContainer/HSplitContainer/VBoxContainer/HBoxContainer/GridMode" to="." method="_on_grid_mode_pressed"]
 [connection signal="pressed" from="VBoxContainer/HSplitContainer/VBoxContainer/LowerToolbar/AddTerrain" to="." method="_on_add_terrain_pressed"]
 [connection signal="pressed" from="VBoxContainer/HSplitContainer/VBoxContainer/LowerToolbar/EditTerrain" to="." method="_on_edit_terrain_pressed"]
 [connection signal="focus_exited" from="VBoxContainer/HSplitContainer/VBoxContainer/LowerToolbar/PickIcon" to="." method="_on_pick_icon_focus_exited"]

--- a/addons/better-terrain/editor/TerrainEntry.gd
+++ b/addons/better-terrain/editor/TerrainEntry.gd
@@ -8,6 +8,7 @@ signal select(index)
 @onready var type_icon_slot := %TypeIcon
 @onready var name_label := %Name
 @onready var layout_container := %Layout
+@onready var icon_layout_container := %IconLayout
 
 var selected := false
 
@@ -15,6 +16,8 @@ var tileset:TileSet
 var terrain:Dictionary
 
 var grid_mode := false
+var color_style_list:StyleBoxFlat
+var color_style_grid:StyleBoxFlat
 
 var _terrain_texture:Texture2D
 var _terrain_texture_rect:Rect2i
@@ -37,9 +40,16 @@ func update():
 	
 	name_label.text = terrain.name
 	
-	var style:StyleBoxFlat = color_panel.get_theme_stylebox("panel").duplicate()
-	style.bg_color = terrain.color
-	color_panel.add_theme_stylebox_override("panel", style)
+	color_style_list = color_panel.get_theme_stylebox("panel").duplicate()
+	color_style_grid = color_panel.get_theme_stylebox("panel").duplicate()
+	color_style_list.bg_color = terrain.color
+	color_style_list.corner_radius_top_left = 8
+	color_style_list.corner_radius_bottom_left = 8
+	color_style_grid.bg_color = terrain.color
+	color_style_list.corner_radius_top_left = 6
+	color_style_list.corner_radius_bottom_left = 6
+	color_style_list.corner_radius_top_right = 6
+	color_style_list.corner_radius_bottom_right = 6
 	
 	type_icon_slot.texture = terrain_icons[terrain.type]
 	
@@ -88,11 +98,17 @@ func update_style():
 		size_flags_horizontal = Control.SIZE_FILL
 		layout_container.vertical = true
 		name_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+		color_panel.add_theme_stylebox_override("panel", color_style_list)
+		color_panel.size_flags_vertical = Control.SIZE_SHRINK_BEGIN
+		icon_layout_container.add_theme_constant_override("separation", -24)
 	else:
 		custom_minimum_size = Vector2(2000, 60)
 		size_flags_horizontal = Control.SIZE_EXPAND_FILL
 		layout_container.vertical = false
 		name_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_LEFT
+		color_panel.add_theme_stylebox_override("panel", color_style_grid)
+		color_panel.size_flags_vertical = Control.SIZE_FILL
+		icon_layout_container.add_theme_constant_override("separation", 4)
 
 
 func set_selected(value:bool = true):

--- a/addons/better-terrain/editor/TerrainEntry.gd
+++ b/addons/better-terrain/editor/TerrainEntry.gd
@@ -1,0 +1,98 @@
+@tool
+extends PanelContainer
+
+signal select(index)
+
+@onready var color_panel := %Color
+@onready var terrain_icon_slot := %TerrainIcon
+@onready var type_icon_slot := %TypeIcon
+@onready var name_label := %Name
+
+var selected := false
+
+var tileset:TileSet
+var terrain:Dictionary
+
+var _terrain_texture:Texture2D
+var _terrain_texture_rect:Rect2i
+var _icon_draw_connected := false
+
+@onready var terrain_icons := [
+	load("res://addons/better-terrain/icons/MatchTiles.svg"),
+	load("res://addons/better-terrain/icons/MatchVertices.svg"),
+	load("res://addons/better-terrain/icons/NonModifying.svg"),
+]
+
+func _ready():
+	update()
+
+func update():
+	if !terrain:
+		return
+	if !tileset:
+		return
+	
+	name_label.text = terrain.name
+	
+	var style:StyleBoxFlat = color_panel.get_theme_stylebox("panel").duplicate()
+	style.bg_color = terrain.color
+	color_panel.add_theme_stylebox_override("panel", style)
+	
+	type_icon_slot.texture = terrain_icons[terrain.type]
+	
+	var has_icon = false
+	if terrain.has("icon"):
+		if terrain.icon.has("path") and not terrain.icon.path.is_empty():
+			terrain_icon_slot.texture = load(terrain.icon.path)
+			_terrain_texture = null
+			terrain_icon_slot.queue_redraw()
+			has_icon = true
+		elif terrain.icon.has("source_id"):
+			var source := tileset.get_source(terrain.icon.source_id) as TileSetAtlasSource
+			var coord := terrain.icon.coord as Vector2i
+			var rect := source.get_tile_texture_region(coord, 0)
+			_terrain_texture = source.texture
+			_terrain_texture_rect = rect
+			terrain_icon_slot.queue_redraw()
+			has_icon = true
+	
+	if not has_icon:
+		var tiles = BetterTerrain.get_tile_sources_in_terrain(tileset, get_index())
+		if tiles.size() > 0:
+			var source := tiles[0].source as TileSetAtlasSource
+			var coord := tiles[0].coord as Vector2i
+			var rect := source.get_tile_texture_region(coord, 0)
+			_terrain_texture = source.texture
+			_terrain_texture_rect = rect
+			terrain_icon_slot.queue_redraw()
+	
+	if _terrain_texture:
+		terrain_icon_slot.texture = null
+	
+	if not _icon_draw_connected:
+		terrain_icon_slot.connect("draw", func():
+			if _terrain_texture:
+				terrain_icon_slot.draw_texture_rect_region(_terrain_texture, Rect2i(0,0, 44, 44), _terrain_texture_rect)
+		)
+		_icon_draw_connected = true
+
+
+func set_selected(value:bool = true):
+	selected = value
+	if value:
+		select.emit(get_index())
+	queue_redraw()
+
+func _draw():
+	if selected:
+		draw_rect(Rect2(Vector2.ZERO, get_rect().size), Color(0.15, 0.70, 1, 0.3))
+
+
+func _on_focus_entered():
+	queue_redraw()
+	selected = true
+	select.emit(get_index())
+
+
+func _on_focus_exited():
+	queue_redraw()

--- a/addons/better-terrain/editor/TerrainEntry.gd
+++ b/addons/better-terrain/editor/TerrainEntry.gd
@@ -7,11 +7,14 @@ signal select(index)
 @onready var terrain_icon_slot := %TerrainIcon
 @onready var type_icon_slot := %TypeIcon
 @onready var name_label := %Name
+@onready var layout_container := %Layout
 
 var selected := false
 
 var tileset:TileSet
 var terrain:Dictionary
+
+var grid_mode := false
 
 var _terrain_texture:Texture2D
 var _terrain_texture_rect:Rect2i
@@ -75,6 +78,21 @@ func update():
 				terrain_icon_slot.draw_texture_rect_region(_terrain_texture, Rect2i(0,0, 44, 44), _terrain_texture_rect)
 		)
 		_icon_draw_connected = true
+	
+	update_style()
+
+
+func update_style():
+	if grid_mode:
+		custom_minimum_size = Vector2(0, 60)
+		size_flags_horizontal = Control.SIZE_FILL
+		layout_container.vertical = true
+		name_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	else:
+		custom_minimum_size = Vector2(2000, 60)
+		size_flags_horizontal = Control.SIZE_EXPAND_FILL
+		layout_container.vertical = false
+		name_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_LEFT
 
 
 func set_selected(value:bool = true):
@@ -82,6 +100,7 @@ func set_selected(value:bool = true):
 	if value:
 		select.emit(get_index())
 	queue_redraw()
+
 
 func _draw():
 	if selected:

--- a/addons/better-terrain/editor/TerrainEntry.tscn
+++ b/addons/better-terrain/editor/TerrainEntry.tscn
@@ -52,33 +52,35 @@ unique_name_in_owner = true
 layout_mode = 2
 theme_override_constants/separation = 4
 
-[node name="HBoxContainer" type="HBoxContainer" parent="Layout"]
+[node name="IconLayout" type="HBoxContainer" parent="Layout"]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 4
 
-[node name="Color" type="PanelContainer" parent="Layout/HBoxContainer"]
+[node name="Color" type="PanelContainer" parent="Layout/IconLayout"]
 unique_name_in_owner = true
+z_index = 1
 custom_minimum_size = Vector2(24, 24)
 layout_mode = 2
 size_flags_horizontal = 0
 mouse_filter = 1
 theme_override_styles/panel = SubResource("StyleBoxFlat_dqhir")
 
-[node name="PanelContainer" type="PanelContainer" parent="Layout/HBoxContainer/Color"]
+[node name="PanelContainer" type="PanelContainer" parent="Layout/IconLayout/Color"]
 layout_mode = 2
 size_flags_horizontal = 4
 size_flags_vertical = 4
 mouse_filter = 1
 theme_override_styles/panel = SubResource("StyleBoxFlat_rohyw")
 
-[node name="TypeIcon" type="TextureRect" parent="Layout/HBoxContainer/Color/PanelContainer"]
+[node name="TypeIcon" type="TextureRect" parent="Layout/IconLayout/Color/PanelContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 4
 size_flags_vertical = 4
 texture = ExtResource("2_wcwfd")
 
-[node name="Panel" type="PanelContainer" parent="Layout/HBoxContainer"]
+[node name="Panel" type="PanelContainer" parent="Layout/IconLayout"]
 custom_minimum_size = Vector2(52, 52)
 layout_mode = 2
 size_flags_horizontal = 4
@@ -86,7 +88,7 @@ size_flags_vertical = 4
 mouse_filter = 1
 theme_override_styles/panel = SubResource("StyleBoxFlat_xa0fl")
 
-[node name="TerrainIcon" type="TextureRect" parent="Layout/HBoxContainer/Panel"]
+[node name="TerrainIcon" type="TextureRect" parent="Layout/IconLayout/Panel"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(40, 40)
 layout_mode = 2

--- a/addons/better-terrain/editor/TerrainEntry.tscn
+++ b/addons/better-terrain/editor/TerrainEntry.tscn
@@ -41,44 +41,44 @@ draw_center = false
 [node name="TerrainEntry" type="PanelContainer"]
 custom_minimum_size = Vector2(0, 60)
 offset_right = 200.0
-offset_bottom = 54.0
-size_flags_horizontal = 3
+offset_bottom = 60.0
 size_flags_vertical = 3
 focus_mode = 2
 theme_override_styles/panel = SubResource("StyleBoxFlat_3pdcc")
 script = ExtResource("1_o2na3")
 
-[node name="HBoxContainer" type="HBoxContainer" parent="."]
+[node name="Layout" type="BoxContainer" parent="."]
+unique_name_in_owner = true
 layout_mode = 2
 theme_override_constants/separation = 4
 
-[node name="Color" type="PanelContainer" parent="HBoxContainer"]
-unique_name_in_owner = true
-custom_minimum_size = Vector2(24, 0)
+[node name="HBoxContainer" type="HBoxContainer" parent="Layout"]
 layout_mode = 2
+size_flags_horizontal = 4
+
+[node name="Color" type="PanelContainer" parent="Layout/HBoxContainer"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(24, 24)
+layout_mode = 2
+size_flags_horizontal = 0
 mouse_filter = 1
 theme_override_styles/panel = SubResource("StyleBoxFlat_dqhir")
 
-[node name="PanelContainer" type="PanelContainer" parent="HBoxContainer/Color"]
+[node name="PanelContainer" type="PanelContainer" parent="Layout/HBoxContainer/Color"]
 layout_mode = 2
 size_flags_horizontal = 4
 size_flags_vertical = 4
 mouse_filter = 1
 theme_override_styles/panel = SubResource("StyleBoxFlat_rohyw")
 
-[node name="TypeIcon" type="TextureRect" parent="HBoxContainer/Color/PanelContainer"]
+[node name="TypeIcon" type="TextureRect" parent="Layout/HBoxContainer/Color/PanelContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 4
 size_flags_vertical = 4
 texture = ExtResource("2_wcwfd")
 
-[node name="HBoxContainer" type="HBoxContainer" parent="HBoxContainer"]
-layout_mode = 2
-size_flags_horizontal = 3
-theme_override_constants/separation = 4
-
-[node name="Panel" type="PanelContainer" parent="HBoxContainer/HBoxContainer"]
+[node name="Panel" type="PanelContainer" parent="Layout/HBoxContainer"]
 custom_minimum_size = Vector2(52, 52)
 layout_mode = 2
 size_flags_horizontal = 4
@@ -86,14 +86,14 @@ size_flags_vertical = 4
 mouse_filter = 1
 theme_override_styles/panel = SubResource("StyleBoxFlat_xa0fl")
 
-[node name="TerrainIcon" type="TextureRect" parent="HBoxContainer/HBoxContainer/Panel"]
+[node name="TerrainIcon" type="TextureRect" parent="Layout/HBoxContainer/Panel"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(40, 40)
 layout_mode = 2
 expand_mode = 5
 stretch_mode = 5
 
-[node name="Name" type="Label" parent="HBoxContainer/HBoxContainer"]
+[node name="Name" type="Label" parent="Layout"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3

--- a/addons/better-terrain/editor/TerrainEntry.tscn
+++ b/addons/better-terrain/editor/TerrainEntry.tscn
@@ -1,0 +1,109 @@
+[gd_scene load_steps=8 format=3 uid="uid://u2y444hj182c"]
+
+[ext_resource type="Script" path="res://addons/better-terrain/editor/TerrainEntry.gd" id="1_o2na3"]
+[ext_resource type="Texture2D" uid="uid://d1h1p7pcwdnjk" path="res://addons/better-terrain/icons/MatchTiles.svg" id="2_wcwfd"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_3pdcc"]
+content_margin_left = 4.0
+content_margin_top = 4.0
+content_margin_right = 4.0
+content_margin_bottom = 4.0
+draw_center = false
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_dqhir"]
+bg_color = Color(0.243, 0.816, 0.518, 1)
+corner_radius_top_left = 8
+corner_radius_bottom_left = 8
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_rohyw"]
+content_margin_left = 2.0
+content_margin_top = 2.0
+content_margin_right = 2.0
+content_margin_bottom = 2.0
+bg_color = Color(0, 0, 0, 0.439216)
+corner_radius_top_left = 4
+corner_radius_top_right = 4
+corner_radius_bottom_right = 4
+corner_radius_bottom_left = 4
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_xa0fl"]
+content_margin_left = 4.0
+content_margin_top = 4.0
+content_margin_right = 4.0
+content_margin_bottom = 4.0
+bg_color = Color(0, 0, 0, 0.439216)
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_b4rkm"]
+content_margin_left = 3.0
+bg_color = Color(0, 0, 0, 0.439216)
+draw_center = false
+
+[node name="TerrainEntry" type="PanelContainer"]
+custom_minimum_size = Vector2(0, 60)
+offset_right = 200.0
+offset_bottom = 54.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+focus_mode = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_3pdcc")
+script = ExtResource("1_o2na3")
+
+[node name="HBoxContainer" type="HBoxContainer" parent="."]
+layout_mode = 2
+theme_override_constants/separation = 4
+
+[node name="Color" type="PanelContainer" parent="HBoxContainer"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(24, 0)
+layout_mode = 2
+mouse_filter = 1
+theme_override_styles/panel = SubResource("StyleBoxFlat_dqhir")
+
+[node name="PanelContainer" type="PanelContainer" parent="HBoxContainer/Color"]
+layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
+mouse_filter = 1
+theme_override_styles/panel = SubResource("StyleBoxFlat_rohyw")
+
+[node name="TypeIcon" type="TextureRect" parent="HBoxContainer/Color/PanelContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
+texture = ExtResource("2_wcwfd")
+
+[node name="HBoxContainer" type="HBoxContainer" parent="HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_constants/separation = 4
+
+[node name="Panel" type="PanelContainer" parent="HBoxContainer/HBoxContainer"]
+custom_minimum_size = Vector2(52, 52)
+layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
+mouse_filter = 1
+theme_override_styles/panel = SubResource("StyleBoxFlat_xa0fl")
+
+[node name="TerrainIcon" type="TextureRect" parent="HBoxContainer/HBoxContainer/Panel"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(40, 40)
+layout_mode = 2
+expand_mode = 5
+stretch_mode = 5
+
+[node name="Name" type="Label" parent="HBoxContainer/HBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 1
+theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
+theme_override_constants/outline_size = 0
+theme_override_styles/normal = SubResource("StyleBoxFlat_b4rkm")
+text = "New Terrain"
+vertical_alignment = 1
+text_overrun_behavior = 3
+
+[connection signal="focus_entered" from="." to="." method="_on_focus_entered"]
+[connection signal="focus_exited" from="." to="." method="_on_focus_exited"]

--- a/addons/better-terrain/editor/TerrainProperties.gd
+++ b/addons/better-terrain/editor/TerrainProperties.gd
@@ -3,6 +3,7 @@ extends ConfirmationDialog
 
 @onready var name_edit: LineEdit = $GridContainer/NameEdit
 @onready var color_picker: ColorPickerButton = $GridContainer/ColorPicker
+@onready var icon_edit: LineEdit = $GridContainer/IconEdit
 @onready var type_option: OptionButton = $GridContainer/TypeOption
 @onready var category_label: Label = $GridContainer/CategoryLabel
 @onready var category_container: ScrollContainer = $GridContainer/CategoryContainer
@@ -21,7 +22,11 @@ var terrain_name : String:
 var terrain_color : Color:
 	set(value): color_picker.color = value
 	get: return color_picker.color
-	
+
+var terrain_icon : String:
+	set(value): icon_edit.text = value
+	get: return icon_edit.text
+
 var terrain_type : int:
 	set(value):
 		type_option.selected = value

--- a/addons/better-terrain/editor/TerrainProperties.tscn
+++ b/addons/better-terrain/editor/TerrainProperties.tscn
@@ -7,6 +7,7 @@
 
 [node name="TerrainProperties" type="ConfirmationDialog"]
 title = "Edit terrain properties"
+position = Vector2i(0, 36)
 size = Vector2i(317, 257)
 visible = true
 dialog_hide_on_ok = false
@@ -37,6 +38,15 @@ layout_mode = 2
 size_flags_horizontal = 3
 color = Color(1, 0.262745, 0.498039, 1)
 edit_alpha = false
+
+[node name="IconLabel" type="Label" parent="GridContainer"]
+layout_mode = 2
+text = "Icon"
+
+[node name="IconEdit" type="LineEdit" parent="GridContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+placeholder_text = "Icon path (optional)"
 
 [node name="TypeLabel" type="Label" parent="GridContainer"]
 layout_mode = 2

--- a/addons/better-terrain/editor/TileView.gd
+++ b/addons/better-terrain/editor/TileView.gd
@@ -3,6 +3,7 @@ extends Control
 
 signal paste_occurred
 signal change_zoom_level(value)
+signal terrain_updated(index)
 
 @onready var checkerboard := get_theme_icon("Checkerboard", "EditorIcons")
 
@@ -27,6 +28,9 @@ var selection_rect : Rect2i
 var selected_tile_states : Array[Dictionary] = []
 var copied_tile_states : Array[Dictionary] = []
 var staged_paste_tile_states : Array[Dictionary] = []
+
+var pick_icon_terrain : int = -1
+var pick_icon_terrain_cancel := false
 
 var undo_manager : EditorUndoRedoManager
 var terrain_undo
@@ -455,6 +459,8 @@ func paste_selection():
 	paste_occurred.emit()
 	queue_redraw()
 
+func emit_terrain_updated(index):
+	terrain_updated.emit(index)
 
 func _gui_input(event) -> void:
 	if event is InputEventKey:
@@ -554,6 +560,30 @@ func _gui_input(event) -> void:
 			paint_action = PaintAction.SELECT
 		return
 	
+	if clicked and pick_icon_terrain >= 0:
+		highlighted_tile_part = tile_part_from_position(current_position)
+		if !highlighted_tile_part.valid:
+			return
+		
+		var t = BetterTerrain.get_terrain(tileset, paint)
+		var prev_icon = t.icon.duplicate()
+		var icon = {
+			source_id = highlighted_tile_part.source_id,
+			coord = highlighted_tile_part.coord
+		}
+		undo_manager.create_action("Edit terrain details", UndoRedo.MERGE_DISABLE, tileset)
+		undo_manager.add_do_method(BetterTerrain, &"set_terrain", tileset, paint, t.name, t.color, t.type, t.categories, icon)
+		undo_manager.add_do_method(self, &"emit_terrain_updated", paint)
+		undo_manager.add_undo_method(BetterTerrain, &"set_terrain", tileset, paint, t.name, t.color, t.type, t.categories, prev_icon)
+		undo_manager.add_undo_method(self, &"emit_terrain_updated", paint)
+		undo_manager.commit_action()
+		pick_icon_terrain = -1
+		return
+	
+	if pick_icon_terrain_cancel:
+		pick_icon_terrain = -1
+		pick_icon_terrain_cancel = false
+	
 	if paint >= 0 and clicked:
 		paint_action = PaintAction.NO_ACTION
 		if highlighted_tile_part.valid:
@@ -566,6 +596,7 @@ func _gui_input(event) -> void:
 		else:
 			match [paint_mode, event.button_index]:
 				[PaintMode.SELECT, MOUSE_BUTTON_LEFT]: paint_action = PaintAction.SELECT
+	
 	if (clicked or event is InputEventMouseMotion) and paint_action != PaintAction.NO_ACTION:
 		
 		if paint_action == PaintAction.SELECT:


### PR DESCRIPTION
Closes #19 

Changes the design of terrain entries to include a new Icon box, as well as some other tweaks:

![sx-932](https://github.com/Portponky/better-terrain/assets/9218934/134c8dfa-7766-4293-9ff8-88af61949445)

This change adds a new `icon` data slot to terrains, and allows you to set either an icon path *or* a tileset `source_id` and `coord` compo to choose a tile as the icon. A new "pick icon" button added to the dock allows you to easily choose a tile to become the icon for the selected terrain. The terrain property popup now includes an `icon path` input to allow specifying any image as its icon. All icon changes support undo/redo.

(I went through many different designs for the new look of the terrain entries. While the mockup provided in #19 is very nice it creates a contrast readability issue with bright colors behind the white text, and adding a shadow or outline to the text didn't look good imo.)