### PR TITLE
Removed unnecessary ? on reference values

### DIFF
--- a/addons/better-terrain/BetterTerrain.cs
+++ b/addons/better-terrain/BetterTerrain.cs
@@ -72,7 +72,7 @@ public class BetterTerrain
         return (Array<Godot.Collections.Dictionary<string, Variant>>)betterTerrain.Call(MethodName.GetTerrainCategories, tileMap.TileSet);
     }
 
-    public bool AddTerrain(string name, Color color, TerrainType type, Array<int>? categories = null, Godot.Collections.Dictionary<Variant, Variant>? icon = null)
+    public bool AddTerrain(string name, Color color, TerrainType type, Array<int> categories = null, Godot.Collections.Dictionary<Variant, Variant> icon = null)
     {
         categories ??= new Array<int>();
         icon ??= new Godot.Collections.Dictionary<Variant, Variant>();
@@ -94,7 +94,7 @@ public class BetterTerrain
         return (Godot.Collections.Dictionary<string, Variant>)betterTerrain.Call(MethodName.GetTerrain, tileMap.TileSet, index);
     }
 
-    public bool SetTerrain(int index, string name, Color color, TerrainType type, Array<int>? categories = null, Godot.Collections.Dictionary<Variant, Variant>? icon = null)
+    public bool SetTerrain(int index, string name, Color color, TerrainType type, Array<int> categories = null, Godot.Collections.Dictionary<Variant, Variant> icon = null)
     {
         categories ??= new Array<int>();
         icon ??= new Godot.Collections.Dictionary<Variant, Variant>();


### PR DESCRIPTION
These values are reference type and thus nullable by default (Unless you are using [Nullable contexts](https://learn.microsoft.com/en-us/dotnet/csharp/nullable-references#nullable-contexts)). Defining them as nullable with ? does nothing and causes warnings to show up in editor. 

regarding issue #59 