### PR TITLE
Expose use_seed with documentation

### DIFF
--- a/addons/better-terrain/BetterTerrain.gd
+++ b/addons/better-terrain/BetterTerrain.gd
@@ -1144,3 +1144,9 @@ func apply_terrain_changeset(change: Dictionary) -> void:
 		var placement = change.placements[n]
 		if placement:
 			change.tilemap.set_cell(change.layer, change.cells[n], placement[0], placement[1], placement[2])
+
+## If true, a seed for the [RandomNumberGenerator] is used and [b]BetterTerrain[/b] will determistically calculate a weighted selection for each tile.
+## If false, each placement of a tile will be random.
+func set_use_seed(state: bool):
+	use_seed = state
+

--- a/addons/better-terrain/editor/Dock.gd
+++ b/addons/better-terrain/editor/Dock.gd
@@ -536,7 +536,7 @@ func perform_edit_terrain(index: int, name: String, color: Color, type: int, cat
 
 
 func _on_shuffle_random_pressed():
-	BetterTerrain.use_seed = !shuffle_random.button_pressed 
+	BetterTerrain.set_use_seed(!shuffle_random.button_pressed)
 
 
 func _on_bit_button_pressed(button: BaseButton) -> void:


### PR DESCRIPTION
Hey, thanks for the great addon!

I think exposing the `use_seed` is helpful when users may want to randomize tile placement.

I think the docstring could be improved, but it's a start.


