### PR TITLE
TileView unnecessary refresh fix

### DIFF
--- a/addons/better-terrain/editor/Dock.gd
+++ b/addons/better-terrain/editor/Dock.gd
@@ -251,11 +251,10 @@ func tiles_changed() -> void:
 		
 		source_selector_popup.add_check_item(name, source_id)
 		
-		var set_enabled: bool = true
-		if tile_view.disabled_sources.has(source_id):
-			set_enabled = false
-		
-		source_selector_popup.set_item_checked(source_selector_popup.get_item_index(source_id), set_enabled)
+		source_selector_popup.set_item_checked(
+			source_selector_popup.get_item_index(source_id),
+			not tile_view.disabled_sources.has(source_id)
+		)
 	source_selector.visible = source_selector_popup.item_count > 3 # All, None and more than one source
 	
 	update_tile_view_paint()

--- a/addons/better-terrain/editor/TileView.gd
+++ b/addons/better-terrain/editor/TileView.gd
@@ -102,7 +102,10 @@ func refresh_tileset(ts: TileSet) -> void:
 	tiles_size = Vector2.ZERO
 	alternate_size = Vector2.ZERO
 	alternate_lookup = []
-	# disabled_sources = []
+	disabled_sources = disabled_sources.filter(
+		func(id):
+			return ts.has_source(id)
+	)
 	
 	if !tileset:
 		return


### PR DESCRIPTION
Every time you draw something in the TileView window, the entire tile scene is reset and updated. This leads to resetting of selected view source values and lags when there are a lot of tiles.

This PR is a dirty quick fix of that specific reset behavior, so now you can just manually reselect view sources as needed.