### PR TITLE
Add must-not-match peering constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The dock has terrain types on the left, and tiles on the right. At the bottom of
 Along the top, you will find the following buttons:
 
 * Pen, line, rectangle, and fill tools. These are for drawing in the scene. Right click will erase.
-* Select, change type and change peering connecting types. Note that these are unselected by default to prevent accidental alterations to the terrain settings. You can unselect them after using them.
+* Select, change type and change peering connecting types. Note that these are unselected by default to prevent accidental alterations to the terrain settings. You can unselect them after using them. Clicking an unset peering cell sets it to **match**. Further clicks toggle between **match** and **must-not-match** (filled circle). The "must-not-match" state prevents a tile from being placed when the excluded terrain is present in that direction. Right click erases both match and must-not-match in one step.
 * A zoom slider for the tiles.
 * An option to control the level of randomization used.
 * A layer selector for the scene. Unfortunately, the layer highlight option is not exposed to GDScript, so that is unavailable.

--- a/addons/better-terrain/BetterTerrain.cs
+++ b/addons/better-terrain/BetterTerrain.cs
@@ -147,6 +147,16 @@ public class BetterTerrain
         return (bool)betterTerrain.Call(MethodName.RemoveTilePeeringType, tileMapLayer.TileSet, tileData, (int)peering, type);
     }
 
+    public bool AddTileNotPeeringType(TileData tileData, TileSet.CellNeighbor peering, int type)
+    {
+        return (bool)betterTerrain.Call(MethodName.AddTileNotPeeringType, tileMapLayer.TileSet, tileData, (int)peering, type);
+    }
+
+    public bool RemoveTileNotPeeringType(TileData tileData, TileSet.CellNeighbor peering, int type)
+    {
+        return (bool)betterTerrain.Call(MethodName.RemoveTileNotPeeringType, tileMapLayer.TileSet, tileData, (int)peering, type);
+    }
+
     public Array<TileSet.CellNeighbor> TilePeeringKeys(TileData tileData)
     {
         return (Array<TileSet.CellNeighbor>)betterTerrain.Call(MethodName.TilePeeringKeys, tileData);
@@ -155,6 +165,11 @@ public class BetterTerrain
     public Array<int> TilePeeringTypes(TileData tileData, TileSet.CellNeighbor peering)
     {
         return (Array<int>)betterTerrain.Call(MethodName.TilePeeringTypes, tileData, (int)peering);
+    }
+
+    public Array<int> TileNotPeeringTypes(TileData tileData, TileSet.CellNeighbor peering)
+    {
+        return (Array<int>)betterTerrain.Call(MethodName.TileNotPeeringTypes, tileData, (int)peering);
     }
 
     public Array<TileSet.CellNeighbor> TilePeeringForType(TileData tileData, int type)
@@ -239,8 +254,11 @@ public class BetterTerrain
         public static readonly StringName GetTileSourcesInTerrain = "get_tile_sources_in_terrain";
         public static readonly StringName AddTilePeeringType = "add_tile_peering_type";
         public static readonly StringName RemoveTilePeeringType = "remove_tile_peering_type";
+        public static readonly StringName AddTileNotPeeringType = "add_tile_not_peering_type";
+        public static readonly StringName RemoveTileNotPeeringType = "remove_tile_not_peering_type";
         public static readonly StringName TilePeeringKeys = "tile_peering_keys";
         public static readonly StringName TilePeeringTypes = "tile_peering_types";
+        public static readonly StringName TileNotPeeringTypes = "tile_not_peering_types";
         public static readonly StringName TilePeeringForType = "tile_peering_for_type";
         public static readonly StringName SetCell = "set_cell";
         public static readonly StringName SetCells = "set_cells";

--- a/addons/better-terrain/BetterTerrain.gd
+++ b/addons/better-terrain/BetterTerrain.gd
@@ -124,7 +124,7 @@ func _get_cache(ts: TileSet) -> Array:
 	
 	# Decoration
 	types[-1] = [TileCategory.EMPTY]
-	cache.push_back([[-1, Vector2.ZERO, -1, {}, 1.0]])
+	cache.push_back([[-1, Vector2.ZERO, -1, {}, 1.0, {}]])
 	
 	for s in ts.get_source_count():
 		var source_id := ts.get_source_id(s)
@@ -146,35 +146,46 @@ func _get_cache(ts: TileSet) -> Array:
 				for key in td_meta.keys():
 					if !(key is int):
 						continue
-					
+
 					var targets := []
 					for k in types:
 						if _intersect(types[k], td_meta[key]):
 							targets.push_back(k)
-					
+
 					peering[key] = targets
-				
+
+				# Build inverted peering from "not" dict (same _intersect resolution)
+				var inverted_peering := {}
+				var not_meta = td_meta.get("not", {})
+				for key in not_meta:
+					var targets := []
+					for k in types:
+						if _intersect(types[k], not_meta[key]):
+							targets.push_back(k)
+					inverted_peering[key] = targets
+
 				# Decoration tiles without peering are skipped
 				if td_meta.type == TileCategory.EMPTY and !peering:
 					continue
-				
+
 				var symmetry = td_meta.get("symmetry", SymmetryType.NONE)
 				# Branch out no symmetry tiles early
 				if symmetry == SymmetryType.NONE:
-					cache[td_meta.type].push_back([source_id, coord, alternate, peering, td.probability])
+					cache[td_meta.type].push_back([source_id, coord, alternate, peering, td.probability, inverted_peering])
 					continue
-				
+
 				# calculate the symmetry order for this tile
 				var symmetry_order := 0
 				for flags in data.symmetry_mapping[symmetry]:
 					var symmetric_peering = data.peering_bits_after_symmetry(peering, flags)
 					if symmetric_peering == peering:
 						symmetry_order += 1
-				
+
 				var adjusted_probability = td.probability / symmetry_order
 				for flags in data.symmetry_mapping[symmetry]:
 					var symmetric_peering = data.peering_bits_after_symmetry(peering, flags)
-					cache[td_meta.type].push_back([source_id, coord, alternate | flags, symmetric_peering, adjusted_probability])
+					var symmetric_inverted = data.peering_bits_after_symmetry(inverted_peering, flags)
+					cache[td_meta.type].push_back([source_id, coord, alternate | flags, symmetric_peering, adjusted_probability, symmetric_inverted])
 	
 	return cache
 
@@ -216,7 +227,15 @@ func _clear_invalid_peering_types(ts: TileSet) -> void:
 				if valid_peering_types.has(peering):
 					continue
 				td_meta.erase(peering)
-			
+
+			# Also clean invalid "not" peering entries
+			var not_dict = td_meta.get("not", {})
+			for peering in not_dict.keys():
+				if !valid_peering_types.has(peering):
+					not_dict.erase(peering)
+			if not_dict.is_empty():
+				td_meta.erase("not")
+
 			_set_tile_meta(ts, td, td_meta)
 	
 	# Not strictly necessary
@@ -235,7 +254,10 @@ func _has_invalid_peering_types(ts: TileSet) -> bool:
 			for peering in c[3].keys():
 				if !valid_peering_types.has(peering):
 					return true
-	
+			for peering in c[5].keys():
+				if !valid_peering_types.has(peering):
+					return true
+
 	return false
 
 
@@ -276,7 +298,7 @@ func _weighted_selection(choices: Array, apply_empty_probability: bool):
 	var weight = choices.reduce(func(a, c): return a + c[4], 0.0)
 	
 	if apply_empty_probability and weight < 1.0 and rng.randf() > weight:
-		return [-1, Vector2.ZERO, -1, null, 1.0]
+		return [-1, Vector2.ZERO, -1, {}, 1.0, {}]
 	
 	if choices.size() == 1:
 		return choices[0]
@@ -310,13 +332,20 @@ func _update_tile_tiles(tm: TileMapLayer, coord: Vector2i, types: Dictionary, ca
 		var score := 0
 		for peering in t[3]:
 			score += reward if t[3][peering].has(types[tm.get_neighbor_cell(coord, peering)]) else penalty
-		
+		# Inverted peering (t[5]): reward when the excluded terrain is absent,
+		# penalty when it is present. Using +reward (not 0) is intentional —
+		# "not" bits only appear on tiles that specifically need them, so
+		# rewarding satisfaction lets them outscore generic alternatives.
+		if t[5]:
+			for peering in t[5]:
+				score += penalty if t[5][peering].has(types[tm.get_neighbor_cell(coord, peering)]) else reward
+
 		if score > best_score:
 			best_score = score
 			best = [t]
 		elif score == best_score:
 			best.append(t)
-	
+
 	return _weighted_selection_seeded(best, coord, apply_empty_probability)
 
 
@@ -345,13 +374,16 @@ func _update_tile_vertices(tm: TileMapLayer, coord: Vector2i, types: Dictionary,
 		var score := 0
 		for peering in t[3]:
 			score += reward if _probe(tm, coord, peering, type, types) in t[3][peering] else penalty
-		
+		if t[5]:
+			for peering in t[5]:
+				score += penalty if _probe(tm, coord, peering, type, types) in t[5][peering] else reward
+
 		if score > best_score:
 			best_score = score
 			best = [t]
 		elif score == best_score:
 			best.append(t)
-	
+
 	return _weighted_selection_seeded(best, coord, false)
 
 
@@ -494,21 +526,37 @@ func remove_terrain(ts: TileSet, index: int) -> bool:
 				for peering in td_meta.keys():
 					if !(peering is int):
 						continue
-					
+
 					var fixed_peering = []
 					for p in td_meta[peering]:
 						if p < index:
 							fixed_peering.append(p)
 						elif p > index:
 							fixed_peering.append(p - 1)
-					
+
 					if fixed_peering.is_empty():
 						td_meta.erase(peering)
 					else:
 						td_meta[peering] = fixed_peering
-				
+
+				# Re-index "not" dict entries
+				var not_dict = td_meta.get("not", {})
+				for peering in not_dict.keys():
+					var fixed_not = []
+					for p in not_dict[peering]:
+						if p < index:
+							fixed_not.append(p)
+						elif p > index:
+							fixed_not.append(p - 1)
+					if fixed_not.is_empty():
+						not_dict.erase(peering)
+					else:
+						not_dict[peering] = fixed_not
+				if not_dict.is_empty():
+					td_meta.erase("not")
+
 				_set_tile_meta(ts, td, td_meta)
-	
+
 	ts_meta.terrains.remove_at(index)
 	_set_terrain_meta(ts, ts_meta)
 	
@@ -634,7 +682,7 @@ func swap_terrains(ts: TileSet, index1: int, index2: int) -> bool:
 				for peering in td_meta.keys():
 					if !(peering is int):
 						continue
-					
+
 					var fixed_peering = []
 					for p in td_meta[peering]:
 						if p == index1:
@@ -644,9 +692,22 @@ func swap_terrains(ts: TileSet, index1: int, index2: int) -> bool:
 						else:
 							fixed_peering.append(p)
 					td_meta[peering] = fixed_peering
-				
+
+				# Swap indices in "not" dict entries
+				var not_dict = td_meta.get("not", {})
+				for peering in not_dict:
+					var fixed_not = []
+					for p in not_dict[peering]:
+						if p == index1:
+							fixed_not.append(index2)
+						elif p == index2:
+							fixed_not.append(index1)
+						else:
+							fixed_not.append(p)
+					not_dict[peering] = fixed_not
+
 				_set_tile_meta(ts, td, td_meta)
-	
+
 	var temp = ts_meta.terrains[index1]
 	ts_meta.terrains[index1] = ts_meta.terrains[index2]
 	ts_meta.terrains[index2] = temp
@@ -777,6 +838,11 @@ func add_tile_peering_type(ts: TileSet, td: TileData, peering: int, type: int) -
 	if td_meta.type < TileCategory.EMPTY or td_meta.type >= ts_meta.terrains.size():
 		return false
 	
+	# Mutual exclusivity: type must not be in the "not" list
+	var not_dict = td_meta.get("not", {})
+	if not_dict.has(peering) and not_dict[peering].has(type):
+		return false
+
 	if !td_meta.has(peering):
 		td_meta[peering] = [type]
 	elif !td_meta[peering].has(type):
@@ -808,6 +874,61 @@ func remove_tile_peering_type(ts: TileSet, td: TileData, peering: int, type: int
 	return true
 
 
+## For a [TileSet]'s tile, specified by [TileData], add terrain [code]type[/code]
+## to the must-NOT-match list in direction [code]peering[/code], which is of type
+## [enum TileSet.CellNeighbor]. Mutually exclusive with the normal match list.
+## Returns [code]true[/code] on success.
+func add_tile_not_peering_type(ts: TileSet, td: TileData, peering: int, type: int) -> bool:
+	if !ts or !td or peering < 0 or peering > 15 or type < TileCategory.EMPTY:
+		return false
+
+	var ts_meta := _get_terrain_meta(ts)
+	var td_meta := _get_tile_meta(td)
+	if td_meta.type < TileCategory.EMPTY or td_meta.type >= ts_meta.terrains.size():
+		return false
+
+	# Mutual exclusivity: type must not be in the normal match list
+	if td_meta.has(peering) and td_meta[peering].has(type):
+		return false
+
+	if !td_meta.has("not"):
+		td_meta["not"] = {}
+	var not_dict = td_meta["not"]
+
+	if !not_dict.has(peering):
+		not_dict[peering] = [type]
+	elif !not_dict[peering].has(type):
+		not_dict[peering].append(type)
+	else:
+		return false
+	_set_tile_meta(ts, td, td_meta)
+	_purge_cache(ts)
+	return true
+
+
+## For a [TileSet]'s tile, specified by [TileData], remove terrain [code]type[/code]
+## from the must-NOT-match list in direction [code]peering[/code], which is of type
+## [enum TileSet.CellNeighbor]. Returns [code]true[/code] on success.
+func remove_tile_not_peering_type(ts: TileSet, td: TileData, peering: int, type: int) -> bool:
+	if !ts or !td or peering < 0 or peering > 15 or type < TileCategory.EMPTY:
+		return false
+
+	var td_meta := _get_tile_meta(td)
+	var not_dict = td_meta.get("not", {})
+	if !not_dict.has(peering):
+		return false
+	if !not_dict[peering].has(type):
+		return false
+	not_dict[peering].erase(type)
+	if not_dict[peering].is_empty():
+		not_dict.erase(peering)
+	if not_dict.is_empty():
+		td_meta.erase("not")
+	_set_tile_meta(ts, td, td_meta)
+	_purge_cache(ts)
+	return true
+
+
 ## For the tile specified by [TileData], return an [Array] of peering directions
 ## for which terrain matching is set up. These will be of type [enum TileSet.CellNeighbor].
 func tile_peering_keys(td: TileData) -> Array:
@@ -818,6 +939,10 @@ func tile_peering_keys(td: TileData) -> Array:
 	var result := []
 	for k in td_meta:
 		if k is int:
+			result.append(k)
+	var not_dict = td_meta.get("not", {})
+	for k in not_dict:
+		if k is int and k not in result:
 			result.append(k)
 	return result
 
@@ -832,6 +957,17 @@ func tile_peering_types(td: TileData, peering: int) -> Array:
 	return td_meta[peering].duplicate() if td_meta.has(peering) else []
 
 
+## For the tile specified by [TileData], return the [Array] of terrains that must NOT
+## match for the direction [code]peering[/code] which should be of type [enum TileSet.CellNeighbor].
+func tile_not_peering_types(td: TileData, peering: int) -> Array:
+	if !td or peering < 0 or peering > 15:
+		return []
+
+	var td_meta := _get_tile_meta(td)
+	var not_dict = td_meta.get("not", {})
+	return not_dict[peering].duplicate() if not_dict.has(peering) else []
+
+
 ## For the tile specified by [TileData], return the [Array] of peering directions
 ## for the specified terrain type [code]type[/code].
 func tile_peering_for_type(td: TileData, type: int) -> Array:
@@ -842,7 +978,7 @@ func tile_peering_for_type(td: TileData, type: int) -> Array:
 	var result := []
 	var sides := tile_peering_keys(td)
 	for side in sides:
-		if td_meta[side].has(type):
+		if td_meta.has(side) and td_meta[side].has(type):
 			result.push_back(side)
 	
 	result.sort()

--- a/addons/better-terrain/editor/TerrainUndo.gd
+++ b/addons/better-terrain/editor/TerrainUndo.gd
@@ -80,49 +80,61 @@ func create_peering_restore_point(undo_manager: EditorUndoRedoManager, ts: TileS
 				var peering_dict := {}
 				for c in BetterTerrain.tile_peering_keys(td):
 					peering_dict[c] = BetterTerrain.tile_peering_types(td, c)
+				var not_peering_dict := {}
+				for c in BetterTerrain.tile_peering_keys(td):
+					var npt = BetterTerrain.tile_not_peering_types(td, c)
+					if !npt.is_empty():
+						not_peering_dict[c] = npt
 				var symmetry = BetterTerrain.get_tile_symmetry_type(td)
-				restore.append([source_id, coord, alternate, tile_type, peering_dict, symmetry])
-	
+				restore.append([source_id, coord, alternate, tile_type, peering_dict, symmetry, not_peering_dict])
+
 	undo_manager.add_undo_method(self, &"restore_peering", ts, restore)
 
 
 func create_peering_restore_point_specific(undo_manager: EditorUndoRedoManager, ts: TileSet, protect: int) -> void:
 	var restore := []
-	
+
 	for s in ts.get_source_count():
 		var source_id := ts.get_source_id(s)
 		var source := ts.get_source(source_id) as TileSetAtlasSource
 		if !source:
 			continue
-		
+
 		for t in source.get_tiles_count():
 			var coord := source.get_tile_id(t)
 			for a in source.get_alternative_tiles_count(coord):
 				var alternate := source.get_alternative_tile_id(coord, a)
-				
+
 				var td := source.get_tile_data(coord, alternate)
 				var tile_type := BetterTerrain.get_tile_terrain_type(td)
 				if tile_type == BetterTerrain.TileCategory.NON_TERRAIN:
 					continue
-				
+
 				var to_restore : bool = tile_type == protect
-				
+
 				var terrain := BetterTerrain.get_terrain(ts, tile_type)
 				var cells = BetterTerrain.data.get_terrain_peering_cells(ts, terrain.type)
 				for c in cells:
 					if protect in BetterTerrain.tile_peering_types(td, c):
 						to_restore = true
 						break
-				
+					if protect in BetterTerrain.tile_not_peering_types(td, c):
+						to_restore = true
+						break
+
 				if !to_restore:
 					continue
-				
+
 				var peering_dict := {}
+				var not_peering_dict := {}
 				for c in cells:
 					peering_dict[c] = BetterTerrain.tile_peering_types(td, c)
+					var npt = BetterTerrain.tile_not_peering_types(td, c)
+					if !npt.is_empty():
+						not_peering_dict[c] = npt
 				var symmetry = BetterTerrain.get_tile_symmetry_type(td)
-				restore.append([source_id, coord, alternate, tile_type, peering_dict, symmetry])
-	
+				restore.append([source_id, coord, alternate, tile_type, peering_dict, symmetry, not_peering_dict])
+
 	undo_manager.add_undo_method(self, &"restore_peering", ts, restore)
 
 
@@ -130,14 +142,18 @@ func create_peering_restore_point_tile(undo_manager: EditorUndoRedoManager, ts: 
 	var source := ts.get_source(source_id) as TileSetAtlasSource
 	var td := source.get_tile_data(coord, alternate)
 	var tile_type := BetterTerrain.get_tile_terrain_type(td)
-	
+
 	var restore := []
 	var peering_dict := {}
+	var not_peering_dict := {}
 	for c in BetterTerrain.tile_peering_keys(td):
 		peering_dict[c] = BetterTerrain.tile_peering_types(td, c)
+		var npt = BetterTerrain.tile_not_peering_types(td, c)
+		if !npt.is_empty():
+			not_peering_dict[c] = npt
 	var symmetry = BetterTerrain.get_tile_symmetry_type(td)
-	restore.append([source_id, coord, alternate, tile_type, peering_dict, symmetry])
-	
+	restore.append([source_id, coord, alternate, tile_type, peering_dict, symmetry, not_peering_dict])
+
 	undo_manager.add_undo_method(self, &"restore_peering", ts, restore)
 
 
@@ -153,6 +169,14 @@ func restore_peering(ts: TileSet, restore: Array) -> void:
 				BetterTerrain.remove_tile_peering_type(ts, td, peering, t)
 			for t in peering_types[peering]:
 				BetterTerrain.add_tile_peering_type(ts, td, peering, t)
+		# Restore "not" peering
+		var not_peering_types = r[6] if r.size() > 6 else {}
+		for peering in not_peering_types:
+			var types := BetterTerrain.tile_not_peering_types(td, peering)
+			for t in types:
+				BetterTerrain.remove_tile_not_peering_type(ts, td, peering, t)
+			for t in not_peering_types[peering]:
+				BetterTerrain.add_tile_not_peering_type(ts, td, peering, t)
 		var symmetry = r[5]
 		BetterTerrain.set_tile_symmetry_type(ts, td, symmetry)
 

--- a/addons/better-terrain/editor/TileView.gd
+++ b/addons/better-terrain/editor/TileView.gd
@@ -403,6 +403,15 @@ func _draw_tile_data(texture: Texture2D, rect: Rect2, src_rect: Rect2, td: TileD
 			if paint_terrain.type == BetterTerrain.TerrainType.DECORATION:
 				side_polygon.append(side_polygon[0])
 				draw_polyline(side_polygon, Color.BLACK)
+		elif paint in BetterTerrain.tile_not_peering_types(td, p):
+			# Draw filled circle to indicate "must not match"
+			var side_polygon = transform * BetterTerrain.data.peering_polygon(tileset, terrain.type, p)
+			var bounds := Rect2(side_polygon[0], Vector2.ZERO)
+			for pt in side_polygon:
+				bounds = bounds.expand(pt)
+			var center := bounds.get_center()
+			var radius : float = min(bounds.size.x, bounds.size.y) * 0.25
+			draw_circle(center, radius, Color(paint_terrain.color, 0.9))
 
 
 func _draw_tile_symmetry(texture: Texture2D, rect: Rect2, src_rect: Rect2, td: TileData, draw_icon: bool = true) -> void:
@@ -574,6 +583,14 @@ func _draw() -> void:
 							var side_polygon = BetterTerrain.data.peering_polygon(tileset, paint_terrain_type, p)
 							var color = Color(paint_terrain.color, 0.6)
 							draw_colored_polygon(transform * side_polygon, color)
+						elif state.paint in BetterTerrain.tile_not_peering_types(state.part.data, p):
+							var side_polygon = transform * BetterTerrain.data.peering_polygon(tileset, paint_terrain_type, p)
+							var bounds := Rect2(side_polygon[0], Vector2.ZERO)
+							for pt in side_polygon:
+								bounds = bounds.expand(pt)
+							var center := bounds.get_center()
+							var radius : float = min(bounds.size.x, bounds.size.y) * 0.25
+							draw_circle(center, radius, Color(paint_terrain.color, 0.6))
 				
 				draw_rect(staged_rect, Color.DEEP_PINK, false)
 	
@@ -587,6 +604,10 @@ func delete_selection():
 			if old_peering.has(paint):
 				undo_manager.add_do_method(BetterTerrain, &"remove_tile_peering_type", tileset, t.part.data, side, paint)
 				undo_manager.add_undo_method(BetterTerrain, &"add_tile_peering_type", tileset, t.part.data, side, paint)
+			var old_not_peering = BetterTerrain.tile_not_peering_types(t.part.data, side)
+			if old_not_peering.has(paint):
+				undo_manager.add_do_method(BetterTerrain, &"remove_tile_not_peering_type", tileset, t.part.data, side, paint)
+				undo_manager.add_undo_method(BetterTerrain, &"add_tile_not_peering_type", tileset, t.part.data, side, paint)
 	
 	undo_manager.add_do_method(self, &"queue_redraw")
 	undo_manager.add_undo_method(self, &"queue_redraw")
@@ -729,6 +750,16 @@ func _gui_input(event) -> void:
 						elif old_peering.has(paint) and not new_sides.has(side):
 							undo_manager.add_do_method(BetterTerrain, &"remove_tile_peering_type", tileset, old_tile_part.data, side, paint)
 							undo_manager.add_undo_method(BetterTerrain, &"add_tile_peering_type", tileset, old_tile_part.data, side, paint)
+
+						# Handle "not" peering paste
+						var old_not_peering = BetterTerrain.tile_not_peering_types(old_tile_part.data, side)
+						var new_not_sides = new_tile_state.get("not_sides", [])
+						if new_not_sides.has(side) and not old_not_peering.has(paint):
+							undo_manager.add_do_method(BetterTerrain, &"add_tile_not_peering_type", tileset, old_tile_part.data, side, paint)
+							undo_manager.add_undo_method(BetterTerrain, &"remove_tile_not_peering_type", tileset, old_tile_part.data, side, paint)
+						elif old_not_peering.has(paint) and not new_not_sides.has(side):
+							undo_manager.add_do_method(BetterTerrain, &"remove_tile_not_peering_type", tileset, old_tile_part.data, side, paint)
+							undo_manager.add_undo_method(BetterTerrain, &"add_tile_not_peering_type", tileset, old_tile_part.data, side, paint)
 					
 					var old_symmetry = BetterTerrain.get_tile_symmetry_type(old_tile_part.data)
 					var new_symmetry = new_tile_state.symmetry
@@ -798,11 +829,16 @@ func _gui_input(event) -> void:
 			var selected_tile_parts = tile_parts_from_rect(selection_rect)
 			selected_tile_states = []
 			for t in selected_tile_parts:
+				var not_sides := []
+				for side in range(16):
+					if paint in BetterTerrain.tile_not_peering_types(t.data, side):
+						not_sides.push_back(side)
 				var state := {
 					part = t,
 					base_rect = Rect2(t.rect.position / zoom_level, t.rect.size / zoom_level),
 					paint = paint,
 					sides = BetterTerrain.tile_peering_for_type(t.data, paint),
+					not_sides = not_sides,
 					symmetry = BetterTerrain.get_tile_symmetry_type(t.data)
 				}
 				selected_tile_states.push_back(state)
@@ -845,21 +881,60 @@ func _gui_input(event) -> void:
 						terrain_undo.action_count += 1
 				elif paint_action == PaintAction.DRAW_PEERING:
 					if highlighted_tile_part.has("peering"):
-						if !(paint in BetterTerrain.tile_peering_types(highlighted_tile_part.data, highlighted_tile_part.peering)):
-							undo_manager.create_action("Set tile terrain peering type " + str(terrain_undo.action_index), UndoRedo.MERGE_ALL, tileset, true)
-							terrain_undo.add_do_method(undo_manager, BetterTerrain, &"add_tile_peering_type", [tileset, highlighted_tile_part.data, highlighted_tile_part.peering, paint])
+						var _p = highlighted_tile_part.peering
+						var has_match = paint in BetterTerrain.tile_peering_types(highlighted_tile_part.data, _p)
+						var has_not = paint in BetterTerrain.tile_not_peering_types(highlighted_tile_part.data, _p)
+						if clicked and has_match:
+							# Click on match → toggle to not-match
+							undo_manager.create_action("Toggle peering to not-match " + str(terrain_undo.action_index), UndoRedo.MERGE_ALL, tileset, true)
+							terrain_undo.add_do_method(undo_manager, BetterTerrain, &"remove_tile_peering_type", [tileset, highlighted_tile_part.data, _p, paint])
+							terrain_undo.add_do_method(undo_manager, BetterTerrain, &"add_tile_not_peering_type", [tileset, highlighted_tile_part.data, _p, paint])
 							terrain_undo.add_do_method(undo_manager, self, &"queue_redraw", [])
-							undo_manager.add_undo_method(BetterTerrain, &"remove_tile_peering_type", tileset, highlighted_tile_part.data, highlighted_tile_part.peering, paint)
+							# Undo runs in reverse: remove not-match first, then add match back
+							undo_manager.add_undo_method(self, &"queue_redraw")
+							undo_manager.add_undo_method(BetterTerrain, &"add_tile_peering_type", tileset, highlighted_tile_part.data, _p, paint)
+							undo_manager.add_undo_method(BetterTerrain, &"remove_tile_not_peering_type", tileset, highlighted_tile_part.data, _p, paint)
+							undo_manager.commit_action()
+							terrain_undo.action_count += 1
+							break
+						elif clicked and has_not:
+							# Click on not-match → toggle to match
+							undo_manager.create_action("Toggle peering to match " + str(terrain_undo.action_index), UndoRedo.MERGE_ALL, tileset, true)
+							terrain_undo.add_do_method(undo_manager, BetterTerrain, &"remove_tile_not_peering_type", [tileset, highlighted_tile_part.data, _p, paint])
+							terrain_undo.add_do_method(undo_manager, BetterTerrain, &"add_tile_peering_type", [tileset, highlighted_tile_part.data, _p, paint])
+							terrain_undo.add_do_method(undo_manager, self, &"queue_redraw", [])
+							# Undo runs in reverse: remove match first, then add not-match back
+							undo_manager.add_undo_method(self, &"queue_redraw")
+							undo_manager.add_undo_method(BetterTerrain, &"add_tile_not_peering_type", tileset, highlighted_tile_part.data, _p, paint)
+							undo_manager.add_undo_method(BetterTerrain, &"remove_tile_peering_type", tileset, highlighted_tile_part.data, _p, paint)
+							undo_manager.commit_action()
+							terrain_undo.action_count += 1
+							break
+						elif !has_match and !has_not:
+							# Unset → match (works for both click and drag)
+							undo_manager.create_action("Set tile terrain peering type " + str(terrain_undo.action_index), UndoRedo.MERGE_ALL, tileset, true)
+							terrain_undo.add_do_method(undo_manager, BetterTerrain, &"add_tile_peering_type", [tileset, highlighted_tile_part.data, _p, paint])
+							terrain_undo.add_do_method(undo_manager, self, &"queue_redraw", [])
+							undo_manager.add_undo_method(BetterTerrain, &"remove_tile_peering_type", tileset, highlighted_tile_part.data, _p, paint)
 							undo_manager.add_undo_method(self, &"queue_redraw")
 							undo_manager.commit_action()
 							terrain_undo.action_count += 1
+							if clicked:
+								break
 				elif paint_action == PaintAction.ERASE_PEERING:
 					if highlighted_tile_part.has("peering"):
-						if paint in BetterTerrain.tile_peering_types(highlighted_tile_part.data, highlighted_tile_part.peering):
+						var _p = highlighted_tile_part.peering
+						var has_match = paint in BetterTerrain.tile_peering_types(highlighted_tile_part.data, _p)
+						var has_not = paint in BetterTerrain.tile_not_peering_types(highlighted_tile_part.data, _p)
+						if has_match or has_not:
 							undo_manager.create_action("Remove tile terrain peering type " + str(terrain_undo.action_index), UndoRedo.MERGE_ALL, tileset, true)
-							terrain_undo.add_do_method(undo_manager, BetterTerrain, &"remove_tile_peering_type", [tileset, highlighted_tile_part.data, highlighted_tile_part.peering, paint])
+							if has_match:
+								terrain_undo.add_do_method(undo_manager, BetterTerrain, &"remove_tile_peering_type", [tileset, highlighted_tile_part.data, _p, paint])
+								undo_manager.add_undo_method(BetterTerrain, &"add_tile_peering_type", tileset, highlighted_tile_part.data, _p, paint)
+							if has_not:
+								terrain_undo.add_do_method(undo_manager, BetterTerrain, &"remove_tile_not_peering_type", [tileset, highlighted_tile_part.data, _p, paint])
+								undo_manager.add_undo_method(BetterTerrain, &"add_tile_not_peering_type", tileset, highlighted_tile_part.data, _p, paint)
 							terrain_undo.add_do_method(undo_manager, self, &"queue_redraw", [])
-							undo_manager.add_undo_method(BetterTerrain, &"add_tile_peering_type", tileset, highlighted_tile_part.data, highlighted_tile_part.peering, paint)
 							undo_manager.add_undo_method(self, &"queue_redraw")
 							undo_manager.commit_action()
 							terrain_undo.action_count += 1


### PR DESCRIPTION
## Summary

Tiles can now specify that certain terrains must NOT be present in a given peering direction. This is the inverse of the existing match constraint: where match says "this terrain should be here," must-not-match says "this terrain must not be here." Useful for tiles that should only appear where a specific terrain is absent on one or more sides.

## Editor behavior

Peering painting gains a third state. Clicking an unset cell sets it to match. Clicking a matched cell toggles it to must-not-match (drawn as a filled circle). Clicking again toggles back to match. Dragging paints unset cells to match without toggling cells that are already set. Right-click erases both states.

## Demo

https://github.com/user-attachments/assets/e913f0e2-35cd-4ce5-bf4e-80879ec83f4d

## API

Three new GDScript functions mirror the existing peering API:

- `add_tile_not_peering_type(ts, td, peering, type) -> bool`
- `remove_tile_not_peering_type(ts, td, peering, type) -> bool`
- `tile_not_peering_types(td, peering) -> Array`

Match and must-not-match are mutually exclusive per peering direction. Both `add_tile_peering_type` and `add_tile_not_peering_type` enforce this and return `false` if the type is already in the other list.

C# wrappers and StringName entries are included.

## Tile solving

Both `_update_tile_tiles` and `_update_tile_vertices` score must-not-match constraints. A satisfied constraint (excluded terrain is absent) earns the same reward as a satisfied match. A violated constraint (excluded terrain is present) earns the same penalty. Symmetry transforms apply to inverted peering the same way they apply to normal peering.

## Other changes

- `tile_peering_keys` returns directions from both the match and must-not-match dicts
- `tile_peering_for_type` guards against directions that only exist in the must-not-match dict
- `remove_terrain` and `swap_terrains` re-index must-not-match entries
- `_clear_invalid_peering_types` and `_has_invalid_peering_types` cover must-not-match
- Undo/redo (TerrainUndo) saves and restores must-not-match state, backward-compatible with old restore data
- Copy/paste, delete, and paste preview all handle must-not-match
- Cache tuples gain a sixth element for inverted peering; the empty-probability fallback tuple is updated to match
- README updated